### PR TITLE
Add service mark symbol

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -15,6 +15,11 @@ const symbols = [
         "searchTerms": ["trademark", "TM"]
     },
     {
+         "glyph": "℠",
+         "name": "Service Mark",
+         "searchTerms": ["service mark", "SM"]
+    },
+    {
         "glyph": "“",
         "name": "Left Double Quotation Mark",
         "searchTerms": ["quotation", "quote", "double", '"']


### PR DESCRIPTION
# ℠

I had to search for this one the other day — many of the copy paste symbol sites tend to miss it I think.

<p align="right"><a href="https://en.wikipedia.org/wiki/Service_mark" target="_blank">https://en.wikipedia.org/wiki/Service_mark</a></p>