### PR TITLE
Add UTF-8 charset meta tag to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 
 <head>
+  <meta charset="UTF-8">
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:description" content="Dumb website for copying symbols.">
   <meta name="twitter:title" content="symbol.wtf" />


### PR DESCRIPTION
Fixes rendering issues in Safari when opening index.html from the filesystem
