### PR TITLE
Add search bar 🔍 | Split symbols out

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:description" content="Dumb website for copying symbols.">
   <meta name="twitter:title" content="symbol.wtf" />
-
+  <meta charset="UTF-8">
+  <script src="./symbols.js"></script>
   <style name="reset.css">
     html {
       box-sizing: border-box;
@@ -47,6 +48,12 @@
       padding: 1rem;
     }
 
+    .search {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 1rem;
+    }
+
     .symbols {
       max-width: 1200px;
       margin: 0 auto;
@@ -70,6 +77,7 @@
       align-items: center;
       cursor: pointer;
       transition: background 200ms linear;
+      max-height: 50%;
     }
 
     .symbol:hover {
@@ -96,17 +104,18 @@
   </style>
 
   <script>
-    const symbols = [
-      "©", "®", "™", "“", "”", "£", "…", "½", "¼", "∞", "é", "á", "à", "ç", "€",
-      "¥", "₩", "¢", "¤", "œ", "Œ", "æ", "Æ", "✔", "°", "²", "³", "‽"
-    ];
-
-    document.addEventListener("DOMContentLoaded", () => {
+    function renderSymbols(searchTerm = "") {
       const parent = document.querySelector(".symbols");
-      for (const symbol of symbols) {
+      searchTerm = searchTerm.toLowerCase();
+      parent.innerHTML = "";
+      for (const symbolInfo of symbols) {
+        symbolSearchTerms = symbolInfo.searchTerms.join(" ");
+        if (searchTerm != "" && !symbolSearchTerms.toLowerCase().includes(searchTerm)) {
+          continue;
+        }
         const elem = document.createElement("div");
         elem.classList = "symbol";
-        elem.textContent = symbol;
+        elem.textContent = symbolInfo.glyph;
         elem.addEventListener("click", () => {
           const symbol = elem.textContent;
           navigator.clipboard.writeText(symbol);
@@ -115,16 +124,34 @@
           elem.classList = "symbol-clicked";
 
           setTimeout(() => {
-            elem.textContent = symbol;
+            elem.textContent = symbolInfo.glyph;
+            elem.title = symbolInfo.name;
             elem.classList = "symbol";
           }, 1000);
         });
         parent.appendChild(elem);
       }
+    }
+
+    function setSearchListener() {
+      const searchInput = document.querySelector(".search input");
+      searchInput.addEventListener("input", (e) => {
+        console.log(e.target.value)
+        const searchTerm = e.target.value;
+        renderSymbols(searchTerm);
+      });
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      renderSymbols();
+      setSearchListener();      
     });
   </script>
 </head>
 
 <body>
+  <div class="search">
+    <input type="text" placeholder="Feeling lucky?" />
+  </div>
   <div class="symbols"></div>
 </body>

--- a/index.html
+++ b/index.html
@@ -72,12 +72,12 @@
       text-align: center;
       line-height: 100%;
       min-height: 125px;
+      max-height: 80vh;
       display: flex;
       justify-content: center;
       align-items: center;
       cursor: pointer;
       transition: background 200ms linear;
-      max-height: 50%;
     }
 
     .symbol:hover {

--- a/symbols.js
+++ b/symbols.js
@@ -1,0 +1,142 @@
+const symbols = [
+    {
+        "glyph": "©",
+        "name": "Copyright",
+        "searchTerms": ["copyright"]
+    },
+    {
+        "glyph": "®",
+        "name": "Registered Trademark",
+        "searchTerms": ["registered trademark"]
+    },
+    {
+        "glyph": "™",
+        "name": "Trademark",
+        "searchTerms": ["trademark"]
+    },
+    {
+        "glyph": "“",
+        "name": "Left Double Quotation Mark",
+        "searchTerms": ["quotation", "quote", "double"]
+    },
+    {
+        "glyph": "”",
+        "name": "Right Double Quotation Mark",
+        "searchTerms": ["quotation", "quote", "double"]
+    },
+    {
+        "glyph": "£",
+        "name": "Pound",
+        "searchTerms": ["pound"]
+    },
+    {
+        "glyph": "…",
+        "name": "Ellipsis",
+        "searchTerms": ["ellipsis"]
+    },
+    {
+        "glyph": "½",
+        "name": "Half",
+        "searchTerms": ["half"]
+    },
+    {
+        "glyph": "¼",
+        "name": "Quarter",
+        "searchTerms": ["quarter"]
+    },
+    {
+        "glyph": "∞",
+        "name": "Infinity",
+        "searchTerms": ["infinity"]
+    },
+    {
+        "glyph": "é",
+        "name": "E with Acute",
+        "searchTerms": ["acute", "e"]
+    },
+    {
+        "glyph": "á",
+        "name": "A with Acute",
+        "searchTerms": ["acute", "a"]
+    },
+    {
+        "glyph": "à",
+        "name": "A with Grave",
+        "searchTerms": ["grave", "a"]
+    },
+    {
+        "glyph": "ç",
+        "name": "C with Cedilla",
+        "searchTerms": ["cedilla", "c"]
+    },
+    {
+        "glyph": "€",
+        "name": "Euro",
+        "searchTerms": ["euro"]
+    },
+    {
+        "glyph": "¥",
+        "name": "Yen",
+        "searchTerms": ["yen"]
+    },
+    {
+        "glyph": "₩",
+        "name": "Won",
+        "searchTerms": ["won"]
+    },
+    {
+        "glyph": "¢",
+        "name": "Cent",
+        "searchTerms": ["cent"]
+    },
+    {
+        "glyph": "¤",
+        "name": "Currency",
+        "searchTerms": ["currency"]
+    },
+    {
+        "glyph": "œ",
+        "name": "OE",
+        "searchTerms": ["oe"]
+    },
+    {
+        "glyph": "Œ",
+        "name": "OE",
+        "searchTerms": ["oe"]
+    },
+    {
+        "glyph": "æ",
+        "name": "AE",
+        "searchTerms": ["ae"]
+    },
+    {
+        "glyph": "Æ",
+        "name": "AE",
+        "searchTerms": ["ae"]
+    },
+    {
+        "glyph": "✔",
+        "name": "Check",
+        "searchTerms": ["check", "tick"]
+    },
+    {
+        "glyph": "°",
+        "name": "Degree",
+        "searchTerms": ["degree"]
+    },
+    {
+        "glyph": "²",
+        "name": "Squared",
+        "searchTerms": ["squared", "power"]
+    },
+    {
+        "glyph": "³",
+        "name": "Cubed",
+        "searchTerms": ["cubed"]
+    },
+    {
+        "glyph": "‽",
+        "name": "Interrobang",
+        "searchTerms": ["interrobang", "?!"]
+    }
+]


### PR DESCRIPTION
# Split symbols out of the HTML
```js
symbols = {'©', '®', '™'} //has been split into
symbols = {"glyph": "²", "name": "Squared", "searchTerms": ["squared", "power"]}, //etc
```

- No need to worry about symbol contributions breaking HTML
- We can add metadata like `name`, `searchTerms` etc which brings me to....

# Add a rudimentary search bar
A simple search bar has been added which performs a naive search across the symbols.  
It takes data from the array `searchTerms`, concats them and checks for a partial match.  
Should be good enough for a long time. Unless we want _AI and ML and 100,000 symbols_. :)

_Considering `searchTerms` is a separate value, it's full customizable - ✔ will show up on searches for `check`, `tick`, `correct` etc - go wild!_

> _Comments on style_
> Kept the default since it's in line with the general style of the page. Just centered it (WHICH TOOK ME 3 HOURS)
> btw the search results view is endearing - becomes bigger in size with fewer results. Pretty cool, so I let it be.

-----
# Now here's what you came for
_the search!_
![image](https://github.com/samwho/symbol.wtf/assets/45961072/6bbbead9-65b2-43b7-a4cd-a1f122268b80)

_ooh only 2 hits so they're chonky boisss_
![image](https://github.com/samwho/symbol.wtf/assets/45961072/aba5a24d-4d27-429c-97d6-760f3a1e2fbb)

