### PR TITLE
fix: double click

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,8 @@
         elem.classList = "symbol";
         elem.textContent = symbol;
         elem.addEventListener("click", () => {
+          if (elem.classList.contains("symbol-clicked")) return;
+
           const symbol = elem.textContent;
           navigator.clipboard.writeText(symbol);
 


### PR DESCRIPTION
Fixes double clicking a symbol. Previously it contained the `Copied` text inside it due to a race condition. This PR adds a check to make sure that doesn't happen.

Before:

https://github.com/samwho/symbol.wtf/assets/53054099/0138e78e-703f-4136-a9ae-cf9b27867de8

After:

https://github.com/samwho/symbol.wtf/assets/53054099/995b0370-49fe-4d10-9924-b2984f62ed76

