### PR TITLE
Apple logo does not render in most cases.

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -170,9 +170,11 @@ const symbols = [
         "searchTerms": ["times", "x"]
     },
     {
-        "glyph": "",
-        "name": "Apple",
-        "searchTerms": ["apple"]
+        /* Apple logo is in Private Use Area and unlikely to render in most cases. */
+        /* TODO: Add images for characters that are unlikely to render. */
+        "glyph": "\uF8FF",
+        "name": "Apple Logo",
+        "searchTerms": ["apple", "logo"]
     },
     {
         "glyph": "π",


### PR DESCRIPTION
This switches `glyph` to \uF8FF, which should still render properly on MacOS (untested).

Add "logo" to `name` and `searchTerms` in passing.