### PR TITLE
Keep size and padding of symbol boxes

### DIFF
--- a/symbols.css
+++ b/symbols.css
@@ -90,13 +90,13 @@ a {
   margin: 0 auto;
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(125px, 1fr));
 }
 
 .symbols > span {
   text-align: center;
   font-size: 2.5rem;
-  margin: auto;
+  grid-column: 1 / -1;
 }
 
 .symbol {


### PR DESCRIPTION
Thank you for this tool, this will save me from continuously googling symbols 💯 

I am not sure if someone is asking for the change in this PR (you can close this PR if this is not the wanted behavior 😄), but as I was using the page I found the grid behavior a little bit odd. Sometimes, the symbol boxes grew very big or the space between them grew. I changed the grid behavior just a little bit, so the boxes keep their sizing and the padding stays the same.



| Before|      After| 
|----------|-------------|
|![Screenshot 2024-04-21 at 20-47-46 ‽](https://github.com/samwho/symbol.wtf/assets/32902192/537baacd-c2f6-4e26-9d3e-4aeaa1e3b257) | ![Screenshot 2024-04-21 at 20-48-07 ‽](https://github.com/samwho/symbol.wtf/assets/32902192/57b7b117-7aab-42c5-90e0-294621458e1c)  | 