### PR TITLE
Give users the option to add symbols

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 
   <div class="search">
     <input type="text" autofocus placeholder="Search..." />
+    <button id="add_symbol">+</button>
   </div>
 
   <div class="symbols"></div>

--- a/symbols.css
+++ b/symbols.css
@@ -22,6 +22,10 @@
   }
 }
 
+* {
+    --warning-fg-color: red;
+}
+
 *,
 *:before,
 *:after {
@@ -85,6 +89,11 @@ a {
   background-color: var(--main-bg-color);
 }
 
+.search > button {
+  font-size: 3rem;
+  margin-left: 1rem;
+}
+
 .symbols {
   max-width: 1200px;
   margin: 0 auto;
@@ -123,6 +132,13 @@ a {
   overflow: hidden;
 }
 
+.symbol > .glyph > input {
+  width: 50%;
+  font-size: 3rem;
+  color: var(--main-fg-color);
+  background-color: var(--main-bg-color);
+}
+
 .symbol > .name {
   font-size: 1rem;
   text-wrap: nowrap;
@@ -131,6 +147,20 @@ a {
   display: block;
   width: 100%;
   overflow: hidden;
+}
+
+.symbol > .glyph > input {
+  color: var(--main-fg-color);
+  background-color: var(--main-bg-color);
+}
+
+.symbol:hover > .remove:after {
+    color: var(--warning-fg-color);
+    content: "🗑";
+    font-size: 1.2rem;
+    position: absolute;
+    top: 0.3rem;
+    right: 0.5rem;
 }
 
 .symbol:hover {

--- a/symbols.css
+++ b/symbols.css
@@ -156,6 +156,16 @@ a {
   width: 100%;
   overflow: hidden;
 }
+.symbol > .name,
+.symbol.clicked > .copy {
+  display: block;
+}
+
+.symbol.clicked > .name,
+.symbol > .copy {
+  display: none;
+}
+
 
 .symbol > .glyph > input {
   color: var(--main-fg-color);

--- a/symbols.css
+++ b/symbols.css
@@ -1,29 +1,29 @@
 @media (prefers-color-scheme: dark) {
   * {
-    --main-bg-color: #1f1f1fff;
-    --main-fg-color: #f0f0f0ff;
-    --border-color: #666666;
-    --clicked-color: rgb(15, 85, 21);
-    --hover-color: #f7b73322;
-    --link-color: #0077cc;
-    --placeholder-color: #7f7f7fff;
+  --main-bg-color: #1f1f1fff;
+  --main-fg-color: #f0f0f0ff;
+  --border-color: #666666;
+  --clicked-color: rgb(15, 85, 21);
+  --hover-color: #f7b73322;
+  --link-color: #0077cc;
+  --placeholder-color: #7f7f7fff;
   }
 }
 
 @media (not (prefers-color-scheme: dark)) {
   * {
-    --main-bg-color: #f0f0f0ff;
-    --main-fg-color: #1f1f1fff;
-    --border-color: #666666;
-    --clicked-color: #b1e8b6ff;
-    --hover-color: #f7b73322;
-    --link-color: #0077cc;
-    --placeholder-color: #7f7f7fff;
+  --main-bg-color: #f0f0f0ff;
+  --main-fg-color: #1f1f1fff;
+  --border-color: #666666;
+  --clicked-color: #b1e8b6ff;
+  --hover-color: #f7b73322;
+  --link-color: #0077cc;
+  --placeholder-color: #7f7f7fff;
   }
 }
 
 * {
-    --warning-fg-color: red;
+  --warning-fg-color: red;
 }
 
 *,
@@ -167,12 +167,12 @@ a {
 }
 
 .symbol:hover > .remove:after {
-    color: var(--warning-fg-color);
-    content: "🗑";
-    font-size: 1.2rem;
-    position: absolute;
-    top: 0.3rem;
-    right: 0.5rem;
+  color: var(--warning-fg-color);
+  content: "🗑";
+  font-size: 1.2rem;
+  position: absolute;
+  top: 0.3rem;
+  right: 0.5rem;
 }
 
 .symbol.drag:hover > .remove:after {

--- a/symbols.css
+++ b/symbols.css
@@ -127,6 +127,14 @@ a {
   transition: background 200ms linear;
 }
 
+.symbol.drag {
+	opacity: 0.4;
+}
+
+.symbol.over {
+	border: 1px solid var(--border-color);
+}
+
 .symbol > .glyph {
   font-size: 60cqw;
   overflow: hidden;
@@ -154,6 +162,10 @@ a {
   background-color: var(--main-bg-color);
 }
 
+.symbol:hover {
+  background-color: var(--hover-color);
+}
+
 .symbol:hover > .remove:after {
     color: var(--warning-fg-color);
     content: "🗑";
@@ -163,9 +175,10 @@ a {
     right: 0.5rem;
 }
 
-.symbol:hover {
-  background-color: var(--hover-color);
+.symbol.drag:hover > .remove:after {
+	content: "";
 }
+
 
 .clicked {
   background-color: var(--clicked-color) !important;

--- a/symbols.css
+++ b/symbols.css
@@ -1,24 +1,24 @@
 @media (prefers-color-scheme: dark) {
   * {
-  --main-bg-color: #1f1f1fff;
-  --main-fg-color: #f0f0f0ff;
-  --border-color: #666666;
-  --clicked-color: rgb(15, 85, 21);
-  --hover-color: #f7b73322;
-  --link-color: #0077cc;
-  --placeholder-color: #7f7f7fff;
+    --main-bg-color: #1f1f1fff;
+    --main-fg-color: #f0f0f0ff;
+    --border-color: #666666;
+    --clicked-color: rgb(15, 85, 21);
+    --hover-color: #f7b73322;
+    --link-color: #0077cc;
+    --placeholder-color: #7f7f7fff;
   }
 }
 
 @media (not (prefers-color-scheme: dark)) {
   * {
-  --main-bg-color: #f0f0f0ff;
-  --main-fg-color: #1f1f1fff;
-  --border-color: #666666;
-  --clicked-color: #b1e8b6ff;
-  --hover-color: #f7b73322;
-  --link-color: #0077cc;
-  --placeholder-color: #7f7f7fff;
+    --main-bg-color: #f0f0f0ff;
+    --main-fg-color: #1f1f1fff;
+    --border-color: #666666;
+    --clicked-color: #b1e8b6ff;
+    --hover-color: #f7b73322;
+    --link-color: #0077cc;
+    --placeholder-color: #7f7f7fff;
   }
 }
 
@@ -128,11 +128,11 @@ a {
 }
 
 .symbol.drag {
-	opacity: 0.4;
+    opacity: 0.4;
 }
 
 .symbol.over {
-	border: 1px solid var(--border-color);
+    border: 1px solid var(--border-color);
 }
 
 .symbol > .glyph {
@@ -176,7 +176,7 @@ a {
 }
 
 .symbol.drag:hover > .remove:after {
-	content: "";
+    content: "";
 }
 
 

--- a/symbols.css
+++ b/symbols.css
@@ -178,7 +178,7 @@ a {
 
 .symbol:hover > .remove:after {
   color: var(--warning-fg-color);
-  content: "🗑";
+  content: "❌";
   font-size: 1.2rem;
   position: absolute;
   top: 0.3rem;

--- a/symbols.css
+++ b/symbols.css
@@ -138,6 +138,8 @@ a {
 .symbol > .glyph {
   font-size: 60cqw;
   overflow: hidden;
+  width: 100%;
+  white-space: nowrap;
 }
 
 .symbol > .glyph > input {

--- a/symbols.js
+++ b/symbols.js
@@ -628,12 +628,17 @@ function handleDragEnter(e) {
 }
 
 function handleDrop(e) {
+	e.preventDefault();
 	let target = e.target;
 	while (target) {
 		if (target.classList?.contains("symbol")) {
 			const parentElem = target.parentElement;
 			const dragIndex = parseInt(parentElem.dataset.dragIndex);
 			const dragTarget = Array.from(parentElem.children).indexOf(target);
+			
+			if (!dragIndex >= 0) {
+				return false;
+			}				
 			
 			symbols.splice(dragTarget, 0, symbols.splice(dragIndex, 1)[0]);
 			window.localStorage.setItem("symbols", JSON.stringify(symbols));

--- a/symbols.js
+++ b/symbols.js
@@ -439,6 +439,7 @@ function addSymbol() {
 }
 
 function editSymbol(elem, classname) {
+	console.log("editSymbol", classname, elem);
     const handleAction = (target) => {
         symbols[target.dataset.index][target.dataset.classname] = target.value;
         if (!symbols[target.dataset.index].name) {
@@ -448,8 +449,10 @@ function editSymbol(elem, classname) {
         target.parentElement.parentElement.title = symbols[target.dataset.index].name;
         target.parentElement.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
+		return true;
     }
     
+	elem.classList.remove("clicked");
     elemClass = elem.getElementsByClassName(classname)[0];
     input = document.createElement("input");    
     input.value = elemClass.innerHTML;
@@ -470,7 +473,7 @@ function isNotEditingSymbol() {
     return document
         .getElementsByClassName("symbols")[0]
         .getElementsByTagName("INPUT")
-        .length === 0
+        .length === 0;
 }
 
 function removeSymbol(elem) {
@@ -506,6 +509,7 @@ function renderSymbols(searchTerm) {
         const elem = document.createElement("div");
         const glyphElem = document.createElement("div");
         const nameElem = document.createElement("div");
+        const copyElem = document.createElement("div");
         const removeElem = document.createElement("div");
 
         elem.classList = "symbol";
@@ -519,33 +523,31 @@ function renderSymbols(searchTerm) {
         nameElem.classList = "name";
         nameElem.textContent = symbol.name;
 
+		copyElem.classList = "copy";
+        copyElem.textContent = "Copied!";
+		
         removeElem.classList = "remove";
         
         elem.appendChild(glyphElem);
         elem.appendChild(nameElem);
+        elem.appendChild(copyElem);
         elem.appendChild(removeElem);
 
         const handleAction = () => {
-            if (elem.classList.contains("clicked")) {
+            if (elem.classList.contains("clicked") || !isNotEditingSymbol()) {
                 return;
             }
 
             navigator.clipboard.writeText(symbol.glyph);
 
             console.log(`Copied ${symbol.name} (${symbol.glyph})!`);
-            nameElem.textContent = "Copied!";
             elem.classList.add("clicked");
 
             setTimeout(() => {
-                nameElem.textContent = symbol.name;
                 elem.classList.remove("clicked");
             }, 1000);
         };
-        elem.addEventListener("click", (event) => {
-            if (isNotEditingSymbol()) {
-                handleAction();
-            }
-        });
+        elem.addEventListener("click", handleAction);
         elem.addEventListener("keydown", (event) => {
             if (isNotEditingSymbol() && (event.key === "Enter" || event.key === " ")
             ) {
@@ -636,6 +638,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     searchInput.addEventListener("blur", (e) => {
         window.location.hash = e.target.value;
+		return false;
     });
 
     window.addEventListener("hashchange", () => {
@@ -649,6 +652,7 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("dblclick", (e) => {
         let target = e.target;
         while(target) {
+			console.log(target);
             if (target.classList?.contains("remove")) {
                 return removeSymbol(target.parentElement);
             }
@@ -656,6 +660,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 return editSymbol(target.parentElement, "glyph");
             }
             if (target.classList?.contains("name")) {
+                return editSymbol(target.parentElement, "name");
+            }
+            if (target.classList?.contains("copy")) {
                 return editSymbol(target.parentElement, "name");
             }
             if (target.classList?.contains("symbol")) {

--- a/symbols.js
+++ b/symbols.js
@@ -402,7 +402,6 @@ try {
     symbols = JSON.parse(window.localStorage.getItem("symbols"));
 } catch(err) {
     console.error(err);
-    symbols = []
 }
 if (!symbols) {
     symbols = symbols_default;
@@ -439,7 +438,6 @@ function addSymbol() {
 }
 
 function editSymbol(elem, classname) {
-	console.log("editSymbol", classname, elem);
     const handleAction = (target) => {
         symbols[target.dataset.index][target.dataset.classname] = target.value;
         if (!symbols[target.dataset.index].name) {
@@ -567,11 +565,9 @@ function handleDragStart(e) {
 
 
 function handleDragEnd(e) {
-	console.log("End", e.target.title)
     e.target.classList.remove('drag');
 	Array.from(e.target.parentElement.children).forEach(elem => elem.classList.remove("over"));
 }
-
 
 function handleDragOver(e) {
     e.preventDefault();
@@ -590,39 +586,32 @@ function handleDragEnter(e) {
 	}
 }
 
-function handleDragLeave(e) {
-	//console.log("handleDragLeave()", e.target);
-    //e.target.classList.remove('over');
-}
-
 function handleDrop(e) {
-	console.log("drop", e.target.title, e.target)
 	let target = e.target;
 	while (target) {
 		if (target.classList?.contains("symbol")) {
-			target.parentElement.dataset.dragTarget = 
-				Array.from(target.parentElement.children).indexOf(target);
+			const parentElem = target.parentElement;
+			const dragIndex = parseInt(parentElem.dataset.dragIndex);
+			const dragTarget = Array.from(parentElem.children).indexOf(target);
 			
-			symbols.splice(target.parentElement.dataset.dragTarget, 0, symbols.splice(target.parentElement.dataset.dragIndex, 1)[0]);
+			symbols.splice(dragTarget, 0, symbols.splice(dragIndex, 1)[0]);
 			window.localStorage.setItem("symbols", JSON.stringify(symbols));
 			
-			if (parseInt(target.parentElement.dataset.dragIndex) < parseInt(target.parentElement.dataset.dragTarget)) {
+			if (dragIndex < dragTarget) {
 				if (target.nextElementSibling) { 
-					target.nextElementSibling.before(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+					target.nextElementSibling.before(
+						parentElem.children[dragIndex]
+					);
 				} else {
-					target.parentElement.appendChild(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+					parentElem.appendChild(parentElem.children[dragIndex]);
 				}
 			} else {
-				target.before(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+				target.before(parentElem.children[dragIndex]);
 			}
 			break;
 		}
 		target = target.parentElement;
 	}
-	
-
-	;
-	
 	e.stopPropagation();
 	return false;
 }
@@ -652,7 +641,6 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("dblclick", (e) => {
         let target = e.target;
         while(target) {
-			console.log(target);
             if (target.classList?.contains("remove")) {
                 return removeSymbol(target.parentElement);
             }
@@ -675,7 +663,6 @@ document.addEventListener("DOMContentLoaded", () => {
 	window.addEventListener("dragstart", handleDragStart);
 	window.addEventListener("dragover", handleDragOver);
 	window.addEventListener("dragenter", handleDragEnter);
-	window.addEventListener("dragleave", handleDragLeave);
 	window.addEventListener("dragend", handleDragEnd);
 	window.addEventListener("drop", handleDrop);
 });

--- a/symbols.js
+++ b/symbols.js
@@ -488,10 +488,10 @@ function editSymbol(elem, classname) {
         target.parentElement.parentElement.title = symbols[target.dataset.index].name;
         target.parentElement.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
-		return true;
+        return true;
     }
     
-	elem.classList.remove("clicked");
+    elem.classList.remove("clicked");
     elemClass = elem.getElementsByClassName(classname)[0];
     input = document.createElement("input");    
     input.value = elemClass.innerHTML;
@@ -554,7 +554,7 @@ function renderSymbols(searchTerm) {
         elem.classList = "symbol";
         elem.tabIndex = 0;
         elem.title = symbol.name;
-		elem.setAttribute("draggable", "true");
+        elem.setAttribute("draggable", "true");
 
         glyphElem.classList = "glyph";
         glyphElem.textContent = symbol.display || symbol.glyph;
@@ -562,9 +562,9 @@ function renderSymbols(searchTerm) {
         nameElem.classList = "name";
         nameElem.textContent = symbol.name;
 
-		copyElem.classList = "copy";
+        copyElem.classList = "copy";
         copyElem.textContent = "Copied!";
-		
+        
         removeElem.classList = "remove";
         
         elem.appendChild(glyphElem);
@@ -588,10 +588,17 @@ function renderSymbols(searchTerm) {
         };
         elem.addEventListener("click", handleAction);
         elem.addEventListener("keydown", (event) => {
-            if (isNotEditingSymbol() && (event.key === "Enter" || event.key === " ")
-            ) {
-                event.preventDefault();
-                handleAction();
+            if (isNotEditingSymbol()) {
+                switch (event.key) {
+                    case " ":
+                    case "Enter":
+                        event.preventDefault();
+                        handleAction();
+                        break;
+                    case "Delete":
+                        removeSymbol(event.target);
+                        break;
+                }
             }
         });
         parent.appendChild(elem);
@@ -600,14 +607,14 @@ function renderSymbols(searchTerm) {
 
 function handleDragStart(e) {
     e.target.classList.add('drag');
-	document.getElementsByClassName("symbols")[0].dataset.dragIndex = 
-		Array.from(e.target.parentElement.children).indexOf(e.target);
+    document.getElementsByClassName("symbols")[0].dataset.dragIndex = 
+        Array.from(e.target.parentElement.children).indexOf(e.target);
 }
 
 
 function handleDragEnd(e) {
     e.target.classList.remove('drag');
-	Array.from(e.target.parentElement.children).forEach(elem => elem.classList.remove("over"));
+    Array.from(e.target.parentElement.children).forEach(elem => elem.classList.remove("over"));
 }
 
 function handleDragOver(e) {
@@ -616,50 +623,50 @@ function handleDragOver(e) {
 }
 
 function handleDragEnter(e) {
-	Array.from(document.getElementsByClassName("over")).forEach(elem => elem.classList.remove("over"));
-	let target = e.target;
-	while (target) {
-		if (target.classList?.contains("symbol")) {
-			target.classList.add("over");
-			break;
-		}
-		target = target.parentElement
-	}
+    Array.from(document.getElementsByClassName("over")).forEach(elem => elem.classList.remove("over"));
+    let target = e.target;
+    while (target) {
+        if (target.classList?.contains("symbol")) {
+            target.classList.add("over");
+            break;
+        }
+        target = target.parentElement
+    }
 }
 
 function handleDrop(e) {
-	e.preventDefault();
-	let target = e.target;
-	while (target) {
-		if (target.classList?.contains("symbol")) {
-			const parentElem = target.parentElement;
-			const dragIndex = parseInt(parentElem.dataset.dragIndex);
-			const dragTarget = Array.from(parentElem.children).indexOf(target);
-			
-			if (!dragIndex >= 0) {
-				return false;
-			}				
-			
-			symbols.splice(dragTarget, 0, symbols.splice(dragIndex, 1)[0]);
-			window.localStorage.setItem("symbols", JSON.stringify(symbols));
-			
-			if (dragIndex < dragTarget) {
-				if (target.nextElementSibling) { 
-					target.nextElementSibling.before(
-						parentElem.children[dragIndex]
-					);
-				} else {
-					parentElem.appendChild(parentElem.children[dragIndex]);
-				}
-			} else {
-				target.before(parentElem.children[dragIndex]);
-			}
-			break;
-		}
-		target = target.parentElement;
-	}
-	e.stopPropagation();
-	return false;
+    e.preventDefault();
+    let target = e.target;
+    while (target) {
+        if (target.classList?.contains("symbol")) {
+            const parentElem = target.parentElement;
+            const dragIndex = parseInt(parentElem.dataset.dragIndex);
+            const dragTarget = Array.from(parentElem.children).indexOf(target);
+            
+            if (!dragIndex >= 0) {
+                return false;
+            }                
+            
+            symbols.splice(dragTarget, 0, symbols.splice(dragIndex, 1)[0]);
+            window.localStorage.setItem("symbols", JSON.stringify(symbols));
+            
+            if (dragIndex < dragTarget) {
+                if (target.nextElementSibling) { 
+                    target.nextElementSibling.before(
+                        parentElem.children[dragIndex]
+                    );
+                } else {
+                    parentElem.appendChild(parentElem.children[dragIndex]);
+                }
+            } else {
+                target.before(parentElem.children[dragIndex]);
+            }
+            break;
+        }
+        target = target.parentElement;
+    }
+    e.stopPropagation();
+    return false;
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -673,7 +680,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     searchInput.addEventListener("blur", (e) => {
         window.location.hash = e.target.value;
-		return false;
+        return false;
     });
 
     window.addEventListener("hashchange", () => {
@@ -705,10 +712,10 @@ document.addEventListener("DOMContentLoaded", () => {
             target = target.parentElement;
         }
     });
-	
-	window.addEventListener("dragstart", handleDragStart);
-	window.addEventListener("dragover", handleDragOver);
-	window.addEventListener("dragenter", handleDragEnter);
-	window.addEventListener("dragend", handleDragEnd);
-	window.addEventListener("drop", handleDrop);
+    
+    window.addEventListener("dragstart", handleDragStart);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragend", handleDragEnd);
+    window.addEventListener("drop", handleDrop);
 });

--- a/symbols.js
+++ b/symbols.js
@@ -408,8 +408,6 @@ if (!symbols) {
     symbols = symbols_default;
 }
 
-console.log(symbols);
-
 function search(searchTerm) {
     searchTerm = searchTerm?.toLowerCase() ?? "";
 
@@ -447,7 +445,7 @@ function editSymbol(elem, classname) {
             symbols[target.dataset.index].name = symbols[target.dataset.index].glyph;
             target.parentNode.parentNode.getElementsByClassName("name")[0].textContent = symbols[target.dataset.index].name;
         }
-		target.parentNode.parentNode.title = symbols[target.dataset.index].name;
+        target.parentNode.parentNode.title = symbols[target.dataset.index].name;
         target.parentNode.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
     }
@@ -466,6 +464,13 @@ function editSymbol(elem, classname) {
     elemClass.innerHTML = '';
     elemClass.appendChild(input);
     input.focus();
+}
+
+function isEditingSymbol() {
+    return document
+        .getElementsByClassName("symbols")[0]
+        .getElementsByTagName("INPUT")
+        .length === 0
 }
 
 function removeSymbol(elem) {
@@ -520,6 +525,7 @@ function renderSymbols(searchTerm) {
         elem.appendChild(removeElem);
 
         const handleAction = () => {
+            console.log("handleAction");
             if (elem.classList.contains("clicked")) {
                 return;
             }
@@ -536,14 +542,14 @@ function renderSymbols(searchTerm) {
             }, 1000);
         };
         elem.addEventListener("click", (event) => {
-            if (!(document.getElementsByClassName("symbols")[0].getElementsByTagName("INPUT"))) {
+            console.log(event);
+            if (isEditingSymbol()) {
+                console.log("handleAction");
                 handleAction();
             }
         });
         elem.addEventListener("keydown", (event) => {
-            if (
-                !(document.getElementsByClassName("symbols")[0].getElementsByTagName("INPUT")) 
-                && (event.key === "Enter" || event.key === " ")
+            if (isEditingSymbol() && (event.key === "Enter" || event.key === " ")
             ) {
                 event.preventDefault();
                 handleAction();

--- a/symbols.js
+++ b/symbols.js
@@ -446,7 +446,8 @@ function editSymbol(elem, classname) {
         if (!symbols[target.dataset.index].name) {
             symbols[target.dataset.index].name = symbols[target.dataset.index].glyph;
             target.parentNode.parentNode.getElementsByClassName("name")[0].textContent = symbols[target.dataset.index].name;
-        }            
+        }
+		target.parentNode.parentNode.title = symbols[target.dataset.index].name;
         target.parentNode.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
     }

--- a/symbols.js
+++ b/symbols.js
@@ -643,7 +643,7 @@ function handleDrop(e) {
             const dragIndex = parseInt(parentElem.dataset.dragIndex);
             const dragTarget = Array.from(parentElem.children).indexOf(target);
             
-            if (!dragIndex >= 0) {
+            if (!(dragIndex >= 0)) {
                 return false;
             }                
             

--- a/symbols.js
+++ b/symbols.js
@@ -494,9 +494,9 @@ function editSymbol(elem, classname) {
     elem.classList.remove("clicked");
     elemClass = elem.getElementsByClassName(classname)[0];
     input = document.createElement("input");    
-    input.value = elemClass.innerHTML;
     input.dataset.classname = classname;
     input.dataset.index = Array.from(elem.parentElement.children).indexOf(elem);
+    input.value = symbols[input.dataset.index][classname];
     input.addEventListener("blur", (e) => handleAction(e.target))
     input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") {


### PR DESCRIPTION
As suggested in issue #54

I've added a "+"-button at the right side of the search field. Feel free to style the button as you like.

All symbols can be edited by double clicking it. Double clicking the name will open a editbox for the name.
Clicking the trashcan will remove the symbol. (Trashcan is styled in CSS, feel free to change it)

Suggestion: Change the text: "Open a PR!" to "Add it yourself" with a link to the addSymbol function.
That will save to some pull requests and discussions about what symbols to include.
Then the only discussion will be what will be a good set of default symbols.

Also made the symbols draggable, so users can get them in their prefered order.
When a symbol is dragged the opacity is reduced to 40%, 
use the drag class to change the style of dragged symbols.
The target of the symbol gets a solid border,
the class over can be used to change that.


