### PR TITLE
Add various keyboard keys

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -366,6 +366,10 @@ const symbols = [
         name: "Caps Lock (Upwards White Arrow from Bar)"
     },
     {
+        glyph: "⇧",
+        name: "Shift (Upwards White Arrow)"
+    },
+    {
         glyph: "þ",
         name: "lowercase thorn"
     },

--- a/symbols.js
+++ b/symbols.js
@@ -370,6 +370,11 @@ const symbols = [
         name: "Shift (Upwards White Arrow)"
     },
     {
+        glyph: "⌃",
+        name: "Control (Up Arrowhead)",
+        searchTerms: ["ctrl"]
+    },
+    {
         glyph: "þ",
         name: "lowercase thorn"
     },

--- a/symbols.js
+++ b/symbols.js
@@ -359,7 +359,7 @@ const symbols = [
     },
     {
         glyph: "⌥",
-        name: "Option"
+        name: "Option Key"
     },
     {
         glyph: "þ",

--- a/symbols.js
+++ b/symbols.js
@@ -362,6 +362,10 @@ const symbols = [
         name: "Option Key"
     },
     {
+        glyph: "⇪",
+        name: "Caps Lock (Upwards White Arrow from Bar)"
+    },
+    {
         glyph: "þ",
         name: "lowercase thorn"
     },


### PR DESCRIPTION
Adds:
- ⇪ Caps Lock (Upwards White Arrow from Bar)
- ⇧ Shift (Upwards White Arrow)
- ⌃ Control (Up Arrowhead)

I placed these in the same order they appear Apple's [Mac keyboard shortcuts](https://support.apple.com/en-us/HT201236) support article.

Modifies:
- ⌥ Option Key

(Renamed from "Option" to "Option Key" per Unicode naming)
