### PR TITLE
Save and load symbol collections

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-symbol.technetium.be

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+symbol.technetium.be

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 
   <div class="search">
     <input type="text" autofocus placeholder="Search..." />
-    <button id="add_symbol">+</button>
+	<button id="add_symbol">+</button>
+	<button id="save_symbols">💾</button>
   </div>
 
   <div class="symbols"></div>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 
   <div class="search">
     <input type="text" autofocus placeholder="Search..." />
+    <button id="add_symbol">+</button>
   </div>
 
   <div class="symbols"></div>

--- a/symbol/README.md
+++ b/symbol/README.md
@@ -1,0 +1,15 @@
+# Symbol collection
+
+This is a directory containing json files of symbol collections.
+
+One or more collections can be dragged to the floppy disk button.
+The symbols will be replaced by the ones in the collecion file(s).
+
+You can create your one collection file
+by clicking the floppy disk button,
+or using an editor of your choice.
+The default name is symbol.json,
+that can be changed by typing the name (without extension)
+into the search field.
+
+You're welcome to open a Pull Request adding new collections.

--- a/symbol/default.json
+++ b/symbol/default.json
@@ -1,0 +1,438 @@
+[
+	"samwho",
+    {
+        "glyph": "©",
+        "name": "Copyright",
+        "searchTerms": ["(C)"]
+    },
+    {
+        "glyph": "®",
+        "name": "Registered Trademark",
+        "searchTerms": ["(R)"]
+    },
+    {
+        "glyph": "™",
+        "name": "Trademark",
+        "searchTerms": ["TM"]
+    },
+	
+	"punctuation",
+    {
+
+        "glyph": "“",
+        "name": "Left Double Quotation Mark",
+        "searchTerms": ["open", "quote", "\""]
+    },
+    {
+        "glyph": "”",
+        "name": "Right Double Quotation Mark",
+        "searchTerms": ["close", "quote", "\""]
+    },
+    {
+        "glyph": "‘",
+        "name": "Left Single Quotation Mark",
+        "searchTerms": ["open", "quote", "'"]
+    },
+    {
+        "glyph": "’",
+        "name": "Right Single Quotation Mark",
+        "searchTerms": ["close", "quote", "'"]
+    },
+    {
+        "glyph": "—",
+        "name": "Em-dash"
+    },
+    {
+        "glyph": "–",
+        "name": "En-dash",
+        "searchTerms": ["en", "dash"]
+    },
+    {
+        "glyph": "¡",
+        "name": "Inverted Exclamation Mark",
+        "searchTerms": ["!"]
+    },
+    {
+        "glyph": "¿",
+        "name": "Inverted Question Mark",
+        "searchTerms": ["?"]
+    },
+    {
+        "glyph": "‽",
+        "name": "Interrobang",
+        "searchTerms": ["?!"]
+    },
+    {
+        "glyph": "…",
+        "name": "Ellipsis",
+        "searchTerms": ["..."]
+    },
+    {
+        "glyph": "−",
+        "name": "minus",
+        "searchTerms": ["minus", "dash"]
+    },
+    {
+        "glyph": "é",
+        "name": "E with Acute",
+        "searchTerms": ["acute", "e"]
+    },
+    {
+        "glyph": "•",
+        "name": "Vertically Centered Dot",
+        "searchTerms": ["bullet", "."]
+    },
+    {
+        "glyph": "§",
+        "name": "Section",
+        "searchTerms": ["silcrow", "s"]
+    },
+    {
+        "glyph": "¶",
+        "name": "Paragraph",
+        "searchTerms": ["pilcrow", "p"]
+    },
+
+    "currency",
+    {
+        "glyph": "¤",
+        "name": "Currency"
+    },
+    {
+        "glyph": "£",
+        "name": "Pound"
+    },
+    {
+        "glyph": "€",
+        "name": "Euro"
+    },
+    {
+        "glyph": "$",
+        "name": "Dollar Sign"
+    },
+    {
+        "glyph": "¥",
+        "name": "Yen"
+    },
+    {
+        "glyph": "₩",
+        "name": "Won"
+    },
+    {
+        "glyph": "₹",
+        "name": "Rupee"
+    },
+    {
+        "glyph": "¢",
+        "name": "Cent"
+    },
+
+    "math",
+    {
+        "glyph": "±",
+        "name": "Plus-minus",
+        "searchTerms": ["+", "-"]
+    },
+    {
+        "glyph": "×",
+        "name": "Times",
+        "searchTerms": ["multiply", "*", "x"]
+    },
+    {
+        "glyph": "÷",
+        "name": "Divide",
+        "searchTerms": ["/"]
+    },
+    {
+        "glyph": "√",
+        "name": "Square Root",
+        "searchTerms": ["sqrt"]
+    },
+    {
+        "glyph": "∑",
+        "name": "Summation",
+        "searchTerms": ["sum"]
+    },
+    {
+        "glyph": "∏",
+        "name": "Product"
+    },
+    {
+        "glyph": "∫",
+        "name": "Integral"
+    },
+    {
+        "glyph": "∂",
+        "name": "Partial Derivative"
+    },
+    {
+        "glyph": "¹",
+        "name": "Superscript One",
+        "searchTerms": ["power","exponent","1","^1","**1"]
+    },
+    {
+        "glyph": "²",
+        "name": "Superscript Two",
+        "searchTerms": ["squared", "power","exponent","2","^2","**2"]
+    },
+    {
+        "glyph": "³",
+        "name": "Superscript Three",
+        "searchTerms": ["cubed", "power","exponent","3","^3","**3"]
+    },
+    {
+        "glyph": "₀",
+        "name": "Subscript Zero",
+        "searchTerms": ["not", "0", "_0"]
+    },
+    {
+        "glyph": "₁",
+        "name": "Subscript One",
+        "searchTerms": ["1", "_1"]
+    },
+    {
+        "glyph": "₂",
+        "name": "Subscript Two",
+        "searchTerms": ["2", "_2"]
+    },
+    {
+        "glyph": "¼",
+        "name": "One Quarter",
+        "searchTerms": ["fraction", "1/4"]
+    },
+    {
+        "glyph": "½",
+        "name": "One Half",
+        "searchTerms": ["fraction", "1/2"]
+    },
+    {
+        "glyph": "¾",
+        "name": "Three Quarters",
+        "searchTerms": ["fraction", "3/4"]
+    },
+    {
+        "glyph": "∞",
+        "name": "Infinity"
+    },
+    {
+        "glyph": "∅",
+        "name": "Empty Set"
+    },
+    {
+        "glyph": "⌀",
+        "name": "Diameter"
+    },
+    {
+        "glyph": "π",
+        "name": "pi",
+        "searchTerms": ["pie"]
+    },
+    {
+        "glyph": "∆",
+        "name": "Delta"
+    },
+    {
+        "glyph": "ε",
+        "name": "Epsilon"
+    },
+    {
+        "glyph": "µ",
+        "name": "Micro",
+        "searchTerms": ["mu"]
+    },
+    {
+        "glyph": "°",
+        "name": "Degree"
+    },
+
+    "accented characters",
+    {
+        "glyph": "á",
+        "name": "A with Acute"
+    },
+    {
+        "glyph": "à",
+        "name": "A with Grave"
+    },
+    {
+        "glyph": "å",
+        "name": "Latin small letter A with ring above"
+    },
+    {
+        "glyph": "Å",
+        "name": "Latin capital letter A with ring above",
+        "searchTerms": ["angstrom"]
+    },
+    {
+        "glyph": "ä",
+        "name": "Latin small letter A with diaeresis"
+    },
+    {
+        "glyph": "Ä",
+        "name": "Latin capital letter A with diaeresis"
+    },
+    {
+        "glyph": "ç",
+        "name": "C with Cedilla"
+    },
+    {
+        "glyph": "é",
+        "name": "E with Acute"
+    },
+    {
+        "glyph": "ñ",
+        "name": "Latin Small Letter n with Tilde",
+        "searchTerms": ["jalapeno"]
+    },
+    {
+        "glyph": "Ñ",
+        "name": "Latin Capital Letter N with Tilde",
+        "searchTerms": ["jalapeno"]
+    },
+
+    "combined characters",
+    {
+        "glyph": "æ",
+        "name": "AE"
+    },
+    {
+        "glyph": "Æ",
+        "name": "AE"
+    },
+    {
+        "glyph": "œ",
+        "name": "OE"
+    },
+    {
+        "glyph": "Œ",
+        "name": "OE"
+    },
+
+    "miscellaneous",
+    {
+        "glyph": "✔",
+        "name": "Check",
+        "searchTerms": ["tick"]
+    },
+    {
+        "glyph": "←",
+        "name": "Left Arrow"
+    },
+    {
+        "glyph": "→",
+        "name": "Right Arrow"
+    },
+    {
+        "glyph": "↑",
+        "name": "Upwards Arrow"
+    },
+    {
+        "glyph": "↓",
+        "name": "Downwards Arrow"
+    },
+    {
+        "glyph": "↔",
+        "name": "Left Right Arrow"
+    },
+    {
+        "glyph": "↕",
+        "name": "Up Down Arrow"
+    },
+    {
+        "glyph": "~",
+        "name": "Tilde"
+    },
+    {
+        "glyph": "ꩰ",
+        "name": "Khamti Reduplication",
+		"_": "search term is Punycode",
+        "searchTerms": ["xn--8r9a"]
+    },
+    {
+        "glyph": "ဪ",
+        "name": "Myanmar Letter Au",
+		"_": "search term is Punycode",
+        "searchTerms": ["xn--ujd"]
+    },
+    {
+        "glyph": "⌘",
+        "name": "Command (Looped Square)"
+    },
+    {
+        "glyph": "⌥",
+        "name": "Option"
+    },
+    {
+        "glyph": "þ",
+        "name": "lowercase thorn"
+    },
+    {
+        "glyph": "Þ",
+        "name": "uppercase thorn"
+    },
+    {
+        "glyph": "ð",
+        "name": "lowercase eth"
+    },
+    {
+        "glyph": "Ð",
+        "name": "uppercase eth"
+    },
+    {
+        "glyph": "†",
+        "name": "dagger"
+    },
+    {
+        "glyph": "♥",
+        "name": "heart"
+    },
+    {
+        "glyph": "♦",
+        "name": "diamond"
+    },
+    {
+        "glyph": "♣",
+        "name": "club"
+    },
+    {
+        "glyph": "♠",
+        "name": "spade"
+    },
+    {
+        "glyph": "℠",
+        "name": "Service Mark",
+        "searchTerms": ["service mark", "SM"]
+    },
+
+    "invisible characters",
+    {
+        "glyph": "\u00A0",
+        "display": "\u25A1",
+        "name": "No-break Space",
+        "searchTerms": ["&nbsp;", "non-breaking"]
+    },
+    {
+        "glyph": "\u200B",
+        "display": "\u25A1",
+        "name": "Zero Width Space",
+        "searchTerms": ["zwsp"]
+    },
+    {
+        "glyph": "\u200E",
+        "display": "\u25A1",
+        "name": "Left-to-Right",
+        "searchTerms": ["&lrm;", "ltr"]
+    },
+    {
+        "glyph": "\u200F",
+        "display": "\u25A1",
+        "name": "Right-to-Left",
+        "searchTerms": ["&rlm;", "rtl"]
+    },
+
+    "Private Use Area (not official Unicode, may not display)",
+    {
+        "glyph": "\uF8FF",
+        "name": "Apple Logo"
+    }
+]

--- a/symbol/hebrew.json
+++ b/symbol/hebrew.json
@@ -1,0 +1,137 @@
+[
+	{
+		"glyph": "א",
+		"name": "Alef",
+		"searchTerms": ["Hebrew Letter Alef", "Aleph"] 
+	},
+	{
+		"glyph": "ב",
+		"name": "Bet",
+		"searchTerms": ["Hebrew Letter Bet"] 
+	},
+	{
+		"glyph": "ג",
+		"name": "Gimel",
+		"searchTerms": ["Hebrew Letter Gimel"] 
+	},
+	{
+		"glyph": "ד",
+		"name": "Dalet",
+		"searchTerms": ["Hebrew Letter Dalet"] 
+	},
+	{
+		"glyph": "ה",
+		"name": "He",
+		"searchTerms": ["Hebrew Letter He"] 
+	},
+	{
+		"glyph": "ו",
+		"name": "Vav",
+		"searchTerms": ["Hebrew Letter Vav"] 
+	},
+	{
+		"glyph": "ז",
+		"name": "Zayin",
+		"searchTerms": ["Hebrew Letter Zayin"] 
+	},
+	{
+		"glyph": "ח",
+		"name": "Het",
+		"searchTerms": ["Hebrew Letter Het"] 
+	},
+	{
+		"glyph": "ט",
+		"name": "Tet",
+		"searchTerms": ["Hebrew Letter Tet"] 
+	},
+	{
+		"glyph": "י",
+		"name": "Yod",
+		"searchTerms": ["Hebrew Letter Yod"] 
+	},
+	{
+		"glyph": "ך",
+		"name": "Final Kaf",
+		"searchTerms": ["Hebrew Letter Final Kaf"] 
+	},
+	{
+		"glyph": "כ",
+		"name": "Kaf",
+		"searchTerms": ["Hebrew Letter Kaf"] 
+	},
+	{
+		"glyph": "ל",
+		"name": "Lamed",
+		"searchTerms": ["Hebrew Letter Lamed"] 
+	},
+	{
+		"glyph": "ם",
+		"name": "Final Mem",
+		"searchTerms": ["Hebrew Letter Final Mem"] 
+	},
+	{
+		"glyph": "מ",
+		"name": "Mem",
+		"searchTerms": ["Hebrew Letter Mem"] 
+	},
+	{
+		"glyph": "ן",
+		"name": "Final Nun",
+		"searchTerms": ["Hebrew Letter Final Nun"] 
+	},
+	{
+		"glyph": "נ",
+		"name": "Nun",
+		"searchTerms": ["Hebrew Letter Nun"] 
+	},
+	{
+		"glyph": "ס",
+		"name": "Samekh",
+		"searchTerms": ["Hebrew Letter Samekh"] 
+	},
+	{
+		"glyph": "ע",
+		"name": "Ayin",
+		"searchTerms": ["Hebrew Letter Ayin "] 
+	},
+	{
+		"glyph": "ף",
+		"name": "Final Pe",
+		"searchTerms": ["Hebrew Letter Final Pe"] 
+	},
+	{
+		"glyph": "פ",
+		"name": "Pe",
+		"searchTerms": ["Hebrew Letter Pe"] 
+	},
+	{
+		"glyph": "ץ",
+		"name": "Final Tsadi",
+		"searchTerms": ["Hebrew Letter Final Tsadi"] 
+	},
+	{
+		"glyph": "צ",
+		"name": "Tsadi",
+		"searchTerms": ["Hebrew Letter Tsadi"] 
+	},
+	{
+		"glyph": "ק",
+		"name": "Qof",
+		"searchTerms": ["Hebrew Letter Qof"] 
+	},
+	{
+		"glyph": "ר",
+		"name": "Resh",
+		"searchTerms": ["Hebrew Letter Resh"] 
+	},
+	{
+		"glyph": "ש",
+		"name": "Shin",
+		"searchTerms": ["Hebrew Letter Shin"] 
+	},
+	{
+		"glyph": "ת",
+		"name": "Tav",
+		"searchTerms": ["Hebrew Letter Tav"] 
+	}
+]

--- a/symbol/numberset.json
+++ b/symbol/numberset.json
@@ -1,0 +1,48 @@
+[
+	{
+		"glyph": "ℕ",
+		"name": "Naturals",
+		"searchTerms": [
+			"Set of Natural Numbers Symbol",
+			"natnums"
+		]
+	},
+	{
+		"glyph": "ℤ",
+		"name": "Integers",
+		"searchTerms": [
+			"Set of Integer Numbers Symbol"
+		]
+	},
+	{
+		"glyph": "ℚ",
+		"name": "Rationals",
+		"searchTerms": [
+			"Set of Rational Numbers Symbol"
+		]
+	},
+	{
+		"glyph": "ℝ",
+		"name": "Reals",
+		"searchTerms": [
+			"Set of Real Numbers Symbol"
+		]
+	},
+	{
+		"glyph": "ℂ",
+		"name": "Complexes",
+		"searchTerms": [
+			"Set of Complex Numbers Symbol",
+			"cnums"
+		]
+	},
+	{
+		"glyph": "ℍ",
+		"name": "Quaternions",
+		"searchTerms": [
+			"Set of Complex Numbers Symbol",
+			"Hamiltonians",
+			"Set of Hamiltonian Number"
+		]
+	}
+]

--- a/symbols.css
+++ b/symbols.css
@@ -99,6 +99,10 @@ a {
 .search > button#save_symbols {
   font-size: 1.8rem; /* Prevent the large disk icon to make the button bigger than the others */
 }
+.search > button.open {
+  border-style: dashed;
+}
+
 
 .over#save_symbols {
   background-color: var(--hover-color);

--- a/symbols.css
+++ b/symbols.css
@@ -22,6 +22,10 @@
   }
 }
 
+* {
+    --warning-fg-color: red;
+}
+
 *,
 *:before,
 *:after {
@@ -85,6 +89,11 @@ a {
   background-color: var(--main-bg-color);
 }
 
+.search > button {
+  font-size: 3rem;
+  margin-left: 1rem;
+}
+
 .symbols {
   max-width: 1200px;
   margin: 0 auto;
@@ -123,6 +132,13 @@ a {
   overflow: hidden;
 }
 
+.symbol > .glyph > input {
+  width: 50%;
+  font-size: 3rem;
+  color: var(--main-fg-color);
+  background-color: var(--main-bg-color);
+}
+
 .symbol > .name {
   font-size: 1rem;
   text-wrap: nowrap;
@@ -131,6 +147,20 @@ a {
   display: block;
   width: 100%;
   overflow: hidden;
+}
+
+.symbol > .glyph > input {
+  color: var(--main-fg-color);
+  background-color: var(--main-bg-color);
+}
+
+.symbol:hover > .remove:after {
+    color: var(--warning-fg-color);
+    content: "🗑";
+    font-size: 1.2rem;
+    position: absolute;
+    top: 0.3rem;
+    right: 0.5rem;
 }
 
 .symbol:hover {

--- a/symbols.css
+++ b/symbols.css
@@ -156,6 +156,16 @@ a {
   width: 100%;
   overflow: hidden;
 }
+.symbol > .name,
+.symbol.clicked > .copy {
+  display: block;
+}
+
+.symbol.clicked > .name,
+.symbol > .copy {
+  display: none;
+}
+
 
 .symbol > .glyph > input {
   color: var(--main-fg-color);

--- a/symbols.css
+++ b/symbols.css
@@ -1,29 +1,29 @@
 @media (prefers-color-scheme: dark) {
   * {
-    --main-bg-color: #1f1f1fff;
-    --main-fg-color: #f0f0f0ff;
-    --border-color: #666666;
-    --clicked-color: rgb(15, 85, 21);
-    --hover-color: #f7b73322;
-    --link-color: #0077cc;
-    --placeholder-color: #7f7f7fff;
+  --main-bg-color: #1f1f1fff;
+  --main-fg-color: #f0f0f0ff;
+  --border-color: #666666;
+  --clicked-color: rgb(15, 85, 21);
+  --hover-color: #f7b73322;
+  --link-color: #0077cc;
+  --placeholder-color: #7f7f7fff;
   }
 }
 
 @media (not (prefers-color-scheme: dark)) {
   * {
-    --main-bg-color: #f0f0f0ff;
-    --main-fg-color: #1f1f1fff;
-    --border-color: #666666;
-    --clicked-color: #b1e8b6ff;
-    --hover-color: #f7b73322;
-    --link-color: #0077cc;
-    --placeholder-color: #7f7f7fff;
+  --main-bg-color: #f0f0f0ff;
+  --main-fg-color: #1f1f1fff;
+  --border-color: #666666;
+  --clicked-color: #b1e8b6ff;
+  --hover-color: #f7b73322;
+  --link-color: #0077cc;
+  --placeholder-color: #7f7f7fff;
   }
 }
 
 * {
-    --warning-fg-color: red;
+  --warning-fg-color: red;
 }
 
 *,
@@ -167,12 +167,12 @@ a {
 }
 
 .symbol:hover > .remove:after {
-    color: var(--warning-fg-color);
-    content: "🗑";
-    font-size: 1.2rem;
-    position: absolute;
-    top: 0.3rem;
-    right: 0.5rem;
+  color: var(--warning-fg-color);
+  content: "🗑";
+  font-size: 1.2rem;
+  position: absolute;
+  top: 0.3rem;
+  right: 0.5rem;
 }
 
 .symbol.drag:hover > .remove:after {

--- a/symbols.css
+++ b/symbols.css
@@ -127,6 +127,14 @@ a {
   transition: background 200ms linear;
 }
 
+.symbol.drag {
+	opacity: 0.4;
+}
+
+.symbol.over {
+	border: 1px solid var(--border-color);
+}
+
 .symbol > .glyph {
   font-size: 60cqw;
   overflow: hidden;
@@ -154,6 +162,10 @@ a {
   background-color: var(--main-bg-color);
 }
 
+.symbol:hover {
+  background-color: var(--hover-color);
+}
+
 .symbol:hover > .remove:after {
     color: var(--warning-fg-color);
     content: "🗑";
@@ -163,9 +175,10 @@ a {
     right: 0.5rem;
 }
 
-.symbol:hover {
-  background-color: var(--hover-color);
+.symbol.drag:hover > .remove:after {
+	content: "";
 }
+
 
 .clicked {
   background-color: var(--clicked-color) !important;

--- a/symbols.css
+++ b/symbols.css
@@ -1,24 +1,24 @@
 @media (prefers-color-scheme: dark) {
   * {
-  --main-bg-color: #1f1f1fff;
-  --main-fg-color: #f0f0f0ff;
-  --border-color: #666666;
-  --clicked-color: rgb(15, 85, 21);
-  --hover-color: #f7b73322;
-  --link-color: #0077cc;
-  --placeholder-color: #7f7f7fff;
+    --main-bg-color: #1f1f1fff;
+    --main-fg-color: #f0f0f0ff;
+    --border-color: #666666;
+    --clicked-color: rgb(15, 85, 21);
+    --hover-color: #f7b73322;
+    --link-color: #0077cc;
+    --placeholder-color: #7f7f7fff;
   }
 }
 
 @media (not (prefers-color-scheme: dark)) {
   * {
-  --main-bg-color: #f0f0f0ff;
-  --main-fg-color: #1f1f1fff;
-  --border-color: #666666;
-  --clicked-color: #b1e8b6ff;
-  --hover-color: #f7b73322;
-  --link-color: #0077cc;
-  --placeholder-color: #7f7f7fff;
+    --main-bg-color: #f0f0f0ff;
+    --main-fg-color: #1f1f1fff;
+    --border-color: #666666;
+    --clicked-color: #b1e8b6ff;
+    --hover-color: #f7b73322;
+    --link-color: #0077cc;
+    --placeholder-color: #7f7f7fff;
   }
 }
 
@@ -128,11 +128,11 @@ a {
 }
 
 .symbol.drag {
-	opacity: 0.4;
+    opacity: 0.4;
 }
 
 .symbol.over {
-	border: 1px solid var(--border-color);
+    border: 1px solid var(--border-color);
 }
 
 .symbol > .glyph {
@@ -176,7 +176,7 @@ a {
 }
 
 .symbol.drag:hover > .remove:after {
-	content: "";
+    content: "";
 }
 
 

--- a/symbols.css
+++ b/symbols.css
@@ -187,8 +187,8 @@ a {
 
 .symbol:hover > .remove:after {
   color: var(--warning-fg-color);
-  content: "❌";
-  font-size: 1.2rem;
+  content: "🗙";
+  font-size: 1.0rem;
   position: absolute;
   top: 0.3rem;
   right: 0.5rem;

--- a/symbols.css
+++ b/symbols.css
@@ -92,9 +92,12 @@ a {
 .search > button {
   font-size: 3rem;
   margin-left: 0.5rem;
-  width: 4rem;
-  text-align: center;
   padding: 0;
+  text-align: center;
+  width: 3.2rem;
+}
+.search > button#save_symbols {
+  font-size: 1.8rem; /* Prevent the large disk icon to make the button bigger than the others */
 }
 
 .over#save_symbols {

--- a/symbols.css
+++ b/symbols.css
@@ -178,7 +178,7 @@ a {
 
 .symbol:hover > .remove:after {
   color: var(--warning-fg-color);
-  content: "🗑";
+  content: "❌";
   font-size: 1.2rem;
   position: absolute;
   top: 0.3rem;

--- a/symbols.css
+++ b/symbols.css
@@ -163,13 +163,16 @@ a {
   background-color: var(--main-bg-color);
 }
 
+.symbol > .copy,
 .symbol > .name {
+  bottom: 15%;
   font-size: 1rem;
+  position: absolute;
   text-wrap: nowrap;
   white-space: nowrap;
   text-overflow: ellipsis;
   display: block;
-  width: 100%;
+  width: 80%;
   overflow: hidden;
 }
 .symbol > .name,

--- a/symbols.css
+++ b/symbols.css
@@ -138,6 +138,8 @@ a {
 .symbol > .glyph {
   font-size: 60cqw;
   overflow: hidden;
+  width: 100%;
+  white-space: nowrap;
 }
 
 .symbol > .glyph > input {

--- a/symbols.css
+++ b/symbols.css
@@ -94,6 +94,10 @@ a {
   margin-left: 1rem;
 }
 
+.over#save_symbols {
+  background-color: var(--hover-color);
+}
+
 .symbols {
   max-width: 1200px;
   margin: 0 auto;

--- a/symbols.css
+++ b/symbols.css
@@ -91,7 +91,10 @@ a {
 
 .search > button {
   font-size: 3rem;
-  margin-left: 1rem;
+  margin-left: 0.5rem;
+  width: 4rem;
+  text-align: center;
+  padding: 0;
 }
 
 .over#save_symbols {
@@ -142,7 +145,7 @@ a {
 .symbol > .glyph {
   font-size: 60cqw;
   overflow: hidden;
-  width: 100%;
+  width: calc(100% + 3rem);
   white-space: nowrap;
 }
 

--- a/symbols.js
+++ b/symbols.js
@@ -439,6 +439,7 @@ function addSymbol() {
 }
 
 function editSymbol(elem, classname) {
+	console.log("editSymbol", classname, elem);
     const handleAction = (target) => {
         symbols[target.dataset.index][target.dataset.classname] = target.value;
         if (!symbols[target.dataset.index].name) {
@@ -448,8 +449,10 @@ function editSymbol(elem, classname) {
         target.parentElement.parentElement.title = symbols[target.dataset.index].name;
         target.parentElement.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
+		return true;
     }
     
+	elem.classList.remove("clicked");
     elemClass = elem.getElementsByClassName(classname)[0];
     input = document.createElement("input");    
     input.value = elemClass.innerHTML;
@@ -470,7 +473,7 @@ function isNotEditingSymbol() {
     return document
         .getElementsByClassName("symbols")[0]
         .getElementsByTagName("INPUT")
-        .length === 0
+        .length === 0;
 }
 
 function removeSymbol(elem) {
@@ -506,6 +509,7 @@ function renderSymbols(searchTerm) {
         const elem = document.createElement("div");
         const glyphElem = document.createElement("div");
         const nameElem = document.createElement("div");
+        const copyElem = document.createElement("div");
         const removeElem = document.createElement("div");
 
         elem.classList = "symbol";
@@ -519,33 +523,31 @@ function renderSymbols(searchTerm) {
         nameElem.classList = "name";
         nameElem.textContent = symbol.name;
 
+		copyElem.classList = "copy";
+        copyElem.textContent = "Copied!";
+		
         removeElem.classList = "remove";
         
         elem.appendChild(glyphElem);
         elem.appendChild(nameElem);
+        elem.appendChild(copyElem);
         elem.appendChild(removeElem);
 
         const handleAction = () => {
-            if (elem.classList.contains("clicked")) {
+            if (elem.classList.contains("clicked") || !isNotEditingSymbol()) {
                 return;
             }
 
             navigator.clipboard.writeText(symbol.glyph);
 
             console.log(`Copied ${symbol.name} (${symbol.glyph})!`);
-            nameElem.textContent = "Copied!";
             elem.classList.add("clicked");
 
             setTimeout(() => {
-                nameElem.textContent = symbol.name;
                 elem.classList.remove("clicked");
             }, 1000);
         };
-        elem.addEventListener("click", (event) => {
-            if (isNotEditingSymbol()) {
-                handleAction();
-            }
-        });
+        elem.addEventListener("click", handleAction);
         elem.addEventListener("keydown", (event) => {
             if (isNotEditingSymbol() && (event.key === "Enter" || event.key === " ")
             ) {
@@ -636,6 +638,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     searchInput.addEventListener("blur", (e) => {
         window.location.hash = e.target.value;
+		return false;
     });
 
     window.addEventListener("hashchange", () => {
@@ -649,6 +652,7 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("dblclick", (e) => {
         let target = e.target;
         while(target) {
+			console.log(target);
             if (target.classList?.contains("remove")) {
                 return removeSymbol(target.parentElement);
             }
@@ -656,6 +660,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 return editSymbol(target.parentElement, "glyph");
             }
             if (target.classList?.contains("name")) {
+                return editSymbol(target.parentElement, "name");
+            }
+            if (target.classList?.contains("copy")) {
                 return editSymbol(target.parentElement, "name");
             }
             if (target.classList?.contains("symbol")) {

--- a/symbols.js
+++ b/symbols.js
@@ -494,9 +494,9 @@ function editSymbol(elem, classname) {
     elem.classList.remove("clicked");
     elemClass = elem.getElementsByClassName(classname)[0];
     input = document.createElement("input");    
-    input.value = elemClass.innerHTML;
     input.dataset.classname = classname;
     input.dataset.index = Array.from(elem.parentElement.children).indexOf(elem);
+    input.value = symbols[input.dataset.index][classname];
     input.addEventListener("blur", (e) => handleAction(e.target))
     input.addEventListener("keydown", (e) => {
         if (e.key === "Enter") {
@@ -633,6 +633,7 @@ function fileHandler(file) {
             }
             if (!+dataset.todo) {
                 console.log("Number of files loaded:", dataset.uploads);
+	            window.localStorage.setItem("symbols", JSON.stringify(symbols));
                 renderSymbols();
             }
         }

--- a/symbols.js
+++ b/symbols.js
@@ -632,6 +632,19 @@ function renderSymbols(searchTerm) {
     }
 }
 
+function openElement(elem) {
+    elem.classList.add("open");
+    elem.dataset.open_counter |= 0;
+    elem.dataset.open_counter++;
+    window.setTimeout((elem) => {
+        elem.dataset.open_counter--;
+        console.warn(elem.dataset.open_counter, +elem.dataset.open_counter)
+        if (+elem.dataset.open_counter === 0) {
+            elem.classList.remove("open");
+        }
+    }, 5000, elem);
+}
+
 function fileHandler(file) {
     if (file.type === "application/json") {
         const dataset = document.getElementById("save_symbols").dataset;
@@ -643,7 +656,13 @@ function fileHandler(file) {
             try {
                 const content = sanitise(JSON.parse(reader.result));
                 if (content.length) {
-                    if (!+dataset.uploads) {
+                    if (
+                        !+dataset.uploads && 
+                        !document
+                            .getElementById("save_symbols")
+                            .classList
+                            .contains("open")
+                    ) {
                         symbols = [];
                     }
                     +dataset.uploads++;
@@ -675,6 +694,7 @@ function dropHandler(ev) {
     // Prevent default behavior (Prevent file from being opened)
     ev.preventDefault();
     ev.target.classList.remove("over");
+    openElement(ev.target);
     document.getElementById("save_symbols").dataset.uploads = 0;
     document.getElementById("save_symbols").dataset.todo = 0;
 

--- a/symbols.js
+++ b/symbols.js
@@ -402,7 +402,6 @@ try {
     symbols = JSON.parse(window.localStorage.getItem("symbols"));
 } catch(err) {
     console.error(err);
-    symbols = []
 }
 if (!symbols) {
     symbols = symbols_default;
@@ -439,7 +438,6 @@ function addSymbol() {
 }
 
 function editSymbol(elem, classname) {
-	console.log("editSymbol", classname, elem);
     const handleAction = (target) => {
         symbols[target.dataset.index][target.dataset.classname] = target.value;
         if (!symbols[target.dataset.index].name) {
@@ -567,11 +565,9 @@ function handleDragStart(e) {
 
 
 function handleDragEnd(e) {
-	console.log("End", e.target.title)
     e.target.classList.remove('drag');
 	Array.from(e.target.parentElement.children).forEach(elem => elem.classList.remove("over"));
 }
-
 
 function handleDragOver(e) {
     e.preventDefault();
@@ -590,39 +586,32 @@ function handleDragEnter(e) {
 	}
 }
 
-function handleDragLeave(e) {
-	//console.log("handleDragLeave()", e.target);
-    //e.target.classList.remove('over');
-}
-
 function handleDrop(e) {
-	console.log("drop", e.target.title, e.target)
 	let target = e.target;
 	while (target) {
 		if (target.classList?.contains("symbol")) {
-			target.parentElement.dataset.dragTarget = 
-				Array.from(target.parentElement.children).indexOf(target);
+			const parentElem = target.parentElement;
+			const dragIndex = parseInt(parentElem.dataset.dragIndex);
+			const dragTarget = Array.from(parentElem.children).indexOf(target);
 			
-			symbols.splice(target.parentElement.dataset.dragTarget, 0, symbols.splice(target.parentElement.dataset.dragIndex, 1)[0]);
+			symbols.splice(dragTarget, 0, symbols.splice(dragIndex, 1)[0]);
 			window.localStorage.setItem("symbols", JSON.stringify(symbols));
 			
-			if (parseInt(target.parentElement.dataset.dragIndex) < parseInt(target.parentElement.dataset.dragTarget)) {
+			if (dragIndex < dragTarget) {
 				if (target.nextElementSibling) { 
-					target.nextElementSibling.before(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+					target.nextElementSibling.before(
+						parentElem.children[dragIndex]
+					);
 				} else {
-					target.parentElement.appendChild(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+					parentElem.appendChild(parentElem.children[dragIndex]);
 				}
 			} else {
-				target.before(target.parentElement.children[target.parentElement.dataset.dragIndex]);
+				target.before(parentElem.children[dragIndex]);
 			}
 			break;
 		}
 		target = target.parentElement;
 	}
-	
-
-	;
-	
 	e.stopPropagation();
 	return false;
 }
@@ -652,7 +641,6 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("dblclick", (e) => {
         let target = e.target;
         while(target) {
-			console.log(target);
             if (target.classList?.contains("remove")) {
                 return removeSymbol(target.parentElement);
             }
@@ -675,7 +663,6 @@ document.addEventListener("DOMContentLoaded", () => {
 	window.addEventListener("dragstart", handleDragStart);
 	window.addEventListener("dragover", handleDragOver);
 	window.addEventListener("dragenter", handleDragEnter);
-	window.addEventListener("dragleave", handleDragLeave);
 	window.addEventListener("dragend", handleDragEnd);
 	window.addEventListener("drop", handleDrop);
 });

--- a/symbols.js
+++ b/symbols.js
@@ -440,13 +440,27 @@ let symbols = []
 
 try {
     // Catching invallid json, not an invalid symbol array
-    symbols = JSON.parse(window.localStorage.getItem("symbols"));
+    symbols = sanitise(JSON.parse(window.localStorage.getItem("symbols")));
 } catch(err) {
     console.error(err);
 }
-if (!symbols) {
+if (symbols.length === 0) {
     symbols = symbols_default;
 }
+
+function sanitise(symbols) {
+	if (!Array.isArray(symbols)) {
+		return [];
+	}
+    return symbols.filter((s) => 
+		s !== null &&
+		typeof s === 'object' &&
+		!Array.isArray(s) &&
+		s.hasOwnProperty("glyph") &&
+		s.hasOwnProperty("name")
+	);
+}
+
 
 function search(searchTerm) {
     searchTerm = searchTerm?.toLowerCase() ?? "";
@@ -621,14 +635,16 @@ function fileHandler(file) {
         reader.onloadend = () => {
             +dataset.todo--;
             try {
-                const content = JSON.parse(reader.result);
-                if (!+dataset.uploads) {
-                    symbols = [];
-                }
-                +dataset.uploads++;
-                symbols.push(...content);
-                
-            } catch(err) {
+                const content = sanitise(JSON.parse(reader.result));
+				console.warn(content.length)
+                if (content.length) {
+    				if (!+dataset.uploads) {
+						symbols = [];
+					}
+					+dataset.uploads++;
+					symbols.push(...content);
+				}
+			} catch(err) {
                 console.error(err);
             }
             if (!+dataset.todo) {

--- a/symbols.js
+++ b/symbols.js
@@ -487,8 +487,15 @@ document.addEventListener("DOMContentLoaded", () => {
     const searchInput = document.querySelector(".search input");
     searchInput.value = search;
     searchInput.addEventListener("input", (e) => {
-        const searchTerm = e.target.value;
-        renderSymbols(searchTerm);
-        window.location.hash = searchTerm;
+        renderSymbols(e.target.value);
+    });
+    searchInput.addEventListener("blur", (e) => {
+        window.location.hash = e.target.value;
+    });
+
+    window.addEventListener("hashchange", () => {
+        const search = window.location.hash ? window.location.hash.substring(1) : "";
+        searchInput.value = search;
+        renderSymbols(search);
     });
 });

--- a/symbols.js
+++ b/symbols.js
@@ -449,16 +449,16 @@ if (symbols.length === 0) {
 }
 
 function sanitise(symbols) {
-	if (!Array.isArray(symbols)) {
-		return [];
-	}
+    if (!Array.isArray(symbols)) {
+        return [];
+    }
     return symbols.filter((s) => 
-		s !== null &&
-		typeof s === 'object' &&
-		!Array.isArray(s) &&
-		s.hasOwnProperty("glyph") &&
-		s.hasOwnProperty("name")
-	);
+        s !== null &&
+        typeof s === 'object' &&
+        !Array.isArray(s) &&
+        s.hasOwnProperty("glyph") &&
+        s.hasOwnProperty("name")
+    );
 }
 
 
@@ -513,15 +513,14 @@ function editSymbol(elem, classname) {
     input.value = symbols[input.dataset.index][classname];
     input.addEventListener("blur", (e) => handleAction(e.target))
     input.addEventListener("keydown", (e) => {
-		console.warn(e.key)
-		switch (e.key) {
-			case "Enter":
-				handleAction(e.target);
-				break;
-			case "Escape":
-				e.target.parentElement.textContent = 
-					symbols[e.target.dataset.index][e.target.dataset.classname];
-				break;
+        switch (e.key) {
+            case "Enter":
+                handleAction(e.target);
+                break;
+            case "Escape":
+                e.target.parentElement.textContent = 
+                    symbols[e.target.dataset.index][e.target.dataset.classname];
+                break;
         }
     });
     elemClass.innerHTML = '';
@@ -643,20 +642,19 @@ function fileHandler(file) {
             +dataset.todo--;
             try {
                 const content = sanitise(JSON.parse(reader.result));
-				console.warn(content.length)
                 if (content.length) {
-    				if (!+dataset.uploads) {
-						symbols = [];
-					}
-					+dataset.uploads++;
-					symbols.push(...content);
-				}
-			} catch(err) {
+                    if (!+dataset.uploads) {
+                        symbols = [];
+                    }
+                    +dataset.uploads++;
+                    symbols.push(...content);
+                }
+            } catch(err) {
                 console.error(err);
             }
             if (!+dataset.todo) {
                 console.log("Number of files loaded:", dataset.uploads);
-	            window.localStorage.setItem("symbols", JSON.stringify(symbols));
+                window.localStorage.setItem("symbols", JSON.stringify(symbols));
                 renderSymbols();
             }
         }

--- a/symbols.js
+++ b/symbols.js
@@ -408,8 +408,6 @@ if (!symbols) {
     symbols = symbols_default;
 }
 
-console.log(symbols);
-
 function search(searchTerm) {
     searchTerm = searchTerm?.toLowerCase() ?? "";
 
@@ -447,7 +445,7 @@ function editSymbol(elem, classname) {
             symbols[target.dataset.index].name = symbols[target.dataset.index].glyph;
             target.parentNode.parentNode.getElementsByClassName("name")[0].textContent = symbols[target.dataset.index].name;
         }
-		target.parentNode.parentNode.title = symbols[target.dataset.index].name;
+        target.parentNode.parentNode.title = symbols[target.dataset.index].name;
         target.parentNode.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
     }
@@ -466,6 +464,13 @@ function editSymbol(elem, classname) {
     elemClass.innerHTML = '';
     elemClass.appendChild(input);
     input.focus();
+}
+
+function isEditingSymbol() {
+    return document
+        .getElementsByClassName("symbols")[0]
+        .getElementsByTagName("INPUT")
+        .length === 0
 }
 
 function removeSymbol(elem) {
@@ -520,6 +525,7 @@ function renderSymbols(searchTerm) {
         elem.appendChild(removeElem);
 
         const handleAction = () => {
+            console.log("handleAction");
             if (elem.classList.contains("clicked")) {
                 return;
             }
@@ -536,14 +542,14 @@ function renderSymbols(searchTerm) {
             }, 1000);
         };
         elem.addEventListener("click", (event) => {
-            if (!(document.getElementsByClassName("symbols")[0].getElementsByTagName("INPUT"))) {
+            console.log(event);
+            if (isEditingSymbol()) {
+                console.log("handleAction");
                 handleAction();
             }
         });
         elem.addEventListener("keydown", (event) => {
-            if (
-                !(document.getElementsByClassName("symbols")[0].getElementsByTagName("INPUT")) 
-                && (event.key === "Enter" || event.key === " ")
+            if (isEditingSymbol() && (event.key === "Enter" || event.key === " ")
             ) {
                 event.preventDefault();
                 handleAction();

--- a/symbols.js
+++ b/symbols.js
@@ -656,18 +656,20 @@ function fileHandler(file) {
 }
 
 function dragOverHandler(ev) {
-  // Prevent default behavior (Prevent file from being opened)
   ev.preventDefault();
+  ev.target.classList.add("over");
 }
 
-
+function dragLeaveHandler(ev) {
+  ev.preventDefault();
+  ev.target.classList.remove("over");
+}
 
 function handleDragStart(e) {
     e.target.classList.add('drag');
     document.getElementsByClassName("symbols")[0].dataset.dragIndex = 
         Array.from(e.target.parentElement.children).indexOf(e.target);
 }
-
 
 function handleDragEnd(e) {
     e.target.classList.remove('drag');
@@ -769,6 +771,7 @@ document.addEventListener("DOMContentLoaded", () => {
     
     document.getElementById("save_symbols").addEventListener("drop", dropHandler);
     document.getElementById("save_symbols").addEventListener("dragover", dragOverHandler);
+    document.getElementById("save_symbols").addEventListener("dragleave", dragLeaveHandler);
     
     document.getElementsByClassName("symbols")[0].addEventListener("dragstart", handleDragStart);
     document.getElementsByClassName("symbols")[0].addEventListener("dragover", handleDragOver);

--- a/symbols.js
+++ b/symbols.js
@@ -638,7 +638,6 @@ function openElement(elem) {
     elem.dataset.open_counter++;
     window.setTimeout((elem) => {
         elem.dataset.open_counter--;
-        console.warn(elem.dataset.open_counter, +elem.dataset.open_counter)
         if (+elem.dataset.open_counter === 0) {
             elem.classList.remove("open");
         }
@@ -665,6 +664,7 @@ function fileHandler(file) {
                     ) {
                         symbols = [];
                     }
+                    openElement(document.getElementById("save_symbols"));
                     +dataset.uploads++;
                     symbols.push(...content);
                 }
@@ -694,7 +694,6 @@ function dropHandler(ev) {
     // Prevent default behavior (Prevent file from being opened)
     ev.preventDefault();
     ev.target.classList.remove("over");
-    openElement(ev.target);
     document.getElementById("save_symbols").dataset.uploads = 0;
     document.getElementById("save_symbols").dataset.todo = 0;
 

--- a/symbols.js
+++ b/symbols.js
@@ -446,7 +446,8 @@ function editSymbol(elem, classname) {
         if (!symbols[target.dataset.index].name) {
             symbols[target.dataset.index].name = symbols[target.dataset.index].glyph;
             target.parentNode.parentNode.getElementsByClassName("name")[0].textContent = symbols[target.dataset.index].name;
-        }            
+        }
+		target.parentNode.parentNode.title = symbols[target.dataset.index].name;
         target.parentNode.textContent = target.value;
         window.localStorage.setItem("symbols", JSON.stringify(symbols));
     }

--- a/symbols.js
+++ b/symbols.js
@@ -513,8 +513,15 @@ function editSymbol(elem, classname) {
     input.value = symbols[input.dataset.index][classname];
     input.addEventListener("blur", (e) => handleAction(e.target))
     input.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") {
-            handleAction(e.target);
+		console.warn(e.key)
+		switch (e.key) {
+			case "Enter":
+				handleAction(e.target);
+				break;
+			case "Escape":
+				e.target.parentElement.textContent = 
+					symbols[e.target.dataset.index][e.target.dataset.classname];
+				break;
         }
     });
     elemClass.innerHTML = '';


### PR DESCRIPTION
I could not help to add a save and load button for symbol collections.

This will also solve to problem of accidental deletion of symbols.
They can be restored by simply dragging the (default) collection file to the disc icon.
Multiple files can be dragged together, so users can combine their own combination of symbols.

Invalid files are rejected on several levels:
 * Non json files are rejected by the  dropHandler.
 * Invalid json is rejected by the json parser
 * Invalid symbols are rejected by the sanitise function. See [test.json](https://github.com/samwho/symbol.wtf/files/15091482/test.json) for a test file.

When a user has created their own collection of symbols,
they can save them by clicking the disk icon.
Default name is symbol.json, other names are possible with the search bar.

I've included a collection of symbol collections:
 * `default.json`, the default collection as defined in symbol.js. Suggestion: Make that definition compliant with the JSON standard, so it's easy to cut and paste in the default.json file. You can also paste the file into definition, then you have to put the array through the sanitiser. Since json can not have comments, I've put the comments in the data.
 * `hebrew.json`, intended as an example for symbol collections, chosen because the Hebrew alphabet has a limited set of characters. I leave the creation of a collection of all the Japanese Kanji for somebody else ;-)
 * `numberset.json`, when I saw you rejected the twitter-x, I had to include the symbols used for number sets. Without the twitter-x of course.

I suspect when you accept all pull requests for symbols, you will end up with the complete unicode set. As you already indicated in issue #45, this is way to big not useful for most users. You could suggest users creating their own sets of symbols and accept those as PR's. You could even curtail the current default set and move some symbols to seperate collections.
 