### PR TITLE
Add prime and double-prime symbols

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -245,6 +245,16 @@ const symbols = [
         glyph: "°",
         name: "Degree"
     },
+    {
+        glyph: "′",
+        name: "Prime",
+        searchTerms: ["feet", "minute", "arcminute"]
+    },
+    {
+        glyph: "″",
+        name: "Double prime",
+        searchTerms: ["inch", "second", "arcsecond"]
+    },
 
     /* accented characters */
     {


### PR DESCRIPTION
These are often used for feet and inches ("she was 5′7″ tall"), for minutes and seconds ("John Cage's 4′33″"), or for subdivisions of angles.
