### PR TITLE
add scandinavian ø/Ø letters

### DIFF
--- a/symbols.js
+++ b/symbols.js
@@ -464,6 +464,16 @@ const symbols = [
         glyph: "Œ",
         name: "OE"
     },
+    {
+        glyph: "\u00f8",
+        name: "Latin small letter o with stroke",
+        searchTerms: ["scandinavian ø", "smorrebrod"]
+    },
+    {
+        glyph: "\u00d8",
+        name: "Latin capital letter O with stroke",
+        searchTerms: ["scandinavian Ø", "smorrebrod"]
+    },
 
     /* miscellaneous */
     {


### PR DESCRIPTION
Happy new year!

This PR adds the missing scandinavian letters required for correct spelling of https://da.wikipedia.org/wiki/K%C3%B8benhavn or https://no.wikipedia.org/wiki/Troms%C3%B8