### PR TITLE
`feature/category-filtering`: Add character filtering based on the unicode character category

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
 
   <div class="search">
     <input type="text" autofocus placeholder="Search..." />
+    <select>
+        <option value="" selected>All</option>
+    </select>
   </div>
 
   <div class="symbols"></div>

--- a/symbols.css
+++ b/symbols.css
@@ -79,8 +79,15 @@ a {
 }
 
 .search > input {
-  width: 100%;
+  width: 90%;
   font-size: 3rem;
+  color: var(--main-fg-color);
+  background-color: var(--main-bg-color);
+}
+
+.search > select {
+  width: 10%;
+  font-size: 1rem;
   color: var(--main-fg-color);
   background-color: var(--main-bg-color);
 }

--- a/symbols.css
+++ b/symbols.css
@@ -71,6 +71,7 @@ a {
 
 .search {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   margin: auto;
   margin-bottom: 1em;
@@ -79,15 +80,15 @@ a {
 }
 
 .search > input {
-  width: 90%;
+  width: 100%;
   font-size: 3rem;
   color: var(--main-fg-color);
   background-color: var(--main-bg-color);
 }
 
 .search > select {
-  width: 10%;
-  font-size: 1rem;
+  width: 100%;
+  font-size: 1.2rem;
   color: var(--main-fg-color);
   background-color: var(--main-bg-color);
 }
@@ -146,4 +147,18 @@ a {
 
 .clicked {
   background-color: var(--clicked-color) !important;
+}
+
+@media (min-width: 768px) {
+  .search {
+    flex-direction: row;
+  }
+
+  .search > input {
+    width: 80%;
+  }
+
+  .search > select {
+    width: 20%;
+  }
 }

--- a/symbols.css
+++ b/symbols.css
@@ -71,7 +71,7 @@ a {
 
 .search {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   justify-content: center;
   margin: auto;
   margin-bottom: 1em;
@@ -80,14 +80,17 @@ a {
 }
 
 .search > input {
-  width: 100%;
+  flex: 1;
+  min-width: 80%;
   font-size: 3rem;
   color: var(--main-fg-color);
   background-color: var(--main-bg-color);
+
 }
 
 .search > select {
-  width: 100%;
+  flex: 1;
+  min-width: 10rem;
   font-size: 1.2rem;
   color: var(--main-fg-color);
   background-color: var(--main-bg-color);
@@ -147,18 +150,4 @@ a {
 
 .clicked {
   background-color: var(--clicked-color) !important;
-}
-
-@media (min-width: 768px) {
-  .search {
-    flex-direction: row;
-  }
-
-  .search > input {
-    width: 80%;
-  }
-
-  .search > select {
-    width: 20%;
-  }
 }

--- a/symbols.js
+++ b/symbols.js
@@ -685,14 +685,14 @@ const symbols = [
         name: "Clockwise Rightwards and Leftwards Open Circle Arrows",
         searchTerms: ["media","shuffle","random","randomize"]
     },
-    
+
     /** sus */
     {
         glyph: "⍝",
         name: "APL Functional Symbol Up Shoe Jot",
         searchTerms: ["amogus"]
     },
-    
+
     /** typography */
     {
         glyph: "•",
@@ -927,6 +927,134 @@ const symbols = [
         searchTerms: ["Pause", "Break", "music"]
     }
 ];
+
+const unicodeCategories = [
+    {
+      "code": "Cc",
+      "description": "Other, Control"
+    },
+    {
+      "code": "Cf",
+      "description": "Other, Format"
+    },
+    {
+      "code": "Cn",
+      "description": "Other, Not Assigned (no characters in the file have this property)"
+    },
+    {
+      "code": "Co",
+      "description": "Other, Private Use"
+    },
+    {
+      "code": "Cs",
+      "description": "Other, Surrogate"
+    },
+    {
+      "code": "LC",
+      "description": "Letter, Cased"
+    },
+    {
+      "code": "Ll",
+      "description": "Letter, Lowercase"
+    },
+    {
+      "code": "Lm",
+      "description": "Letter, Modifier"
+    },
+    {
+      "code": "Lo",
+      "description": "Letter, Other"
+    },
+    {
+      "code": "Lt",
+      "description": "Letter, Titlecase"
+    },
+    {
+      "code": "Lu",
+      "description": "Letter, Uppercase"
+    },
+    {
+      "code": "Mc",
+      "description": "Mark, Spacing Combining"
+    },
+    {
+      "code": "Me",
+      "description": "Mark, Enclosing"
+    },
+    {
+      "code": "Mn",
+      "description": "Mark, Nonspacing"
+    },
+    {
+      "code": "Nd",
+      "description": "Number, Decimal Digit"
+    },
+    {
+      "code": "Nl",
+      "description": "Number, Letter"
+    },
+    {
+      "code": "No",
+      "description": "Number, Other"
+    },
+    {
+      "code": "Pc",
+      "description": "Punctuation, Connector"
+    },
+    {
+      "code": "Pd",
+      "description": "Punctuation, Dash"
+    },
+    {
+      "code": "Pe",
+      "description": "Punctuation, Close"
+    },
+    {
+      "code": "Pf",
+      "description": "Punctuation, Final quote (may behave like Ps or Pe depending on usage)"
+    },
+    {
+      "code": "Pi",
+      "description": "Punctuation, Initial quote (may behave like Ps or Pe depending on usage)"
+    },
+    {
+      "code": "Po",
+      "description": "Punctuation, Other"
+    },
+    {
+      "code": "Ps",
+      "description": "Punctuation, Open"
+    },
+    {
+      "code": "Sc",
+      "description": "Symbol, Currency"
+    },
+    {
+      "code": "Sk",
+      "description": "Symbol, Modifier"
+    },
+    {
+      "code": "Sm",
+      "description": "Symbol, Math"
+    },
+    {
+      "code": "So",
+      "description": "Symbol, Other"
+    },
+    {
+      "code": "Zl",
+      "description": "Separator, Line"
+    },
+    {
+      "code": "Zp",
+      "description": "Separator, Paragraph"
+    },
+    {
+      "code": "Zs",
+      "description": "Separator, Space"
+    }
+]
+
 
 function fuzzyMatch(haystack, needle) {
     let haystackIndex = 0;

--- a/symbols.js
+++ b/symbols.js
@@ -1254,6 +1254,28 @@ function renderSymbols(searchTerm) {
     }
 }
 
+function changeUrl(searchString = "") {
+    /* get the category and search from the search input and select */
+    const category = document.querySelector(".search select").value;
+    const search = searchString ? searchString : document.querySelector(".search input").value.trim();
+
+    /* create a new URL object and set the category param and search hash */
+    const lastUrl = window.location.href;
+    const url = new URL(lastUrl);
+    if (category !== "") {
+        url.searchParams.set("category", category);
+    } else {
+        url.searchParams.delete("category");
+    }
+    url.hash = search;
+
+    /* push the new URL to the history if it is different from the last URL,
+    with state containing the category and search */
+    if (url.toString() !== lastUrl) {
+        window.history.pushState({"category": category, "search": search}, '', url.toString());
+    }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     const urlParams = new URLSearchParams(window.location.search);
 
@@ -1272,7 +1294,12 @@ document.addEventListener("DOMContentLoaded", () => {
         renderSymbols(e.target.value.trim());
     });
     searchInput.addEventListener("blur", (e) => {
-        window.location.hash = e.target.value.trim();
+        changeUrl(e.target.value.trim());
+    });
+
+    categorySelect.addEventListener("change", (e) => {
+        changeUrl();
+        renderSymbols(searchInput.value);
     });
 
     window.addEventListener("hashchange", () => {
@@ -1281,9 +1308,11 @@ document.addEventListener("DOMContentLoaded", () => {
         renderSymbols(search);
     });
 
-    categorySelect.addEventListener("change", (e) => {
-        const urlParams = new URLSearchParams(window.location.search);
-        urlParams.set("category", e.target.value);
-        window.location.search = urlParams.toString();
-    });
+    window.addEventListener("popstate", (e) => {
+        /* on popstate event, set the search and category
+        from state (if available) and render symbols */
+        searchInput.value = e.state ? e.state.search : "";
+        categorySelect.value = e.state ? e.state.category : "";
+        renderSymbols(searchInput.value);
+    })
 });

--- a/symbols.js
+++ b/symbols.js
@@ -1146,6 +1146,12 @@ function search(searchTerm) {
         .map(({ symbol }) => symbol);
 }
 
+function isCategoryValid(category){
+    /* check if the category is a valid category code */
+    const categoryCodes = unicodeCategories.map(cat => cat.code);
+    return categoryCodes.includes(category);
+}
+
 function renderSymbols(searchTerm) {
     const parent = document.querySelector(".symbols");
     parent.innerHTML = "";

--- a/symbols.js
+++ b/symbols.js
@@ -1247,12 +1247,19 @@ function renderSymbols(searchTerm) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+    const urlParams = new URLSearchParams(window.location.search);
+
     const search = window.location.hash ? window.location.hash.substring(1) : "";
-    renderSymbols(search);
-    setCategoryNames("");
+    const category = urlParams.get("category");
 
     const searchInput = document.querySelector(".search input");
+    const categorySelect = document.querySelector(".search select");
     searchInput.value = search;
+    categorySelect.value = category;
+
+    setCategoryNames(category);
+    renderSymbols(search);
+
     searchInput.addEventListener("input", (e) => {
         renderSymbols(e.target.value.trim());
     });
@@ -1264,5 +1271,11 @@ document.addEventListener("DOMContentLoaded", () => {
         const search = window.location.hash ? window.location.hash.substring(1) : "";
         searchInput.value = search;
         renderSymbols(search);
+    });
+
+    categorySelect.addEventListener("change", (e) => {
+        const urlParams = new URLSearchParams(window.location.search);
+        urlParams.set("category", e.target.value);
+        window.location.search = urlParams.toString();
     });
 });

--- a/symbols.js
+++ b/symbols.js
@@ -930,130 +930,154 @@ const symbols = [
 
 const unicodeCategories = [
     {
-      "code": "Cc",
-      "description": "Other, Control"
-    },
-    {
-      "code": "Cf",
-      "description": "Other, Format"
-    },
-    {
-      "code": "Cn",
-      "description": "Other, Not Assigned (no characters in the file have this property)"
-    },
-    {
-      "code": "Co",
-      "description": "Other, Private Use"
-    },
-    {
-      "code": "Cs",
-      "description": "Other, Surrogate"
-    },
-    {
-      "code": "LC",
-      "description": "Letter, Cased"
-    },
-    {
-      "code": "Ll",
-      "description": "Letter, Lowercase"
-    },
-    {
-      "code": "Lm",
-      "description": "Letter, Modifier"
-    },
-    {
-      "code": "Lo",
-      "description": "Letter, Other"
-    },
-    {
-      "code": "Lt",
-      "description": "Letter, Titlecase"
+      "code": "L",
+      "description": "Letter"
     },
     {
       "code": "Lu",
-      "description": "Letter, Uppercase"
+      "description": "Uppercase Letter"
     },
     {
-      "code": "Mc",
-      "description": "Mark, Spacing Combining"
+      "code": "Ll",
+      "description": "Lowercase Letter"
     },
     {
-      "code": "Me",
-      "description": "Mark, Enclosing"
+      "code": "Lt",
+      "description": "Titlecase Letter"
+    },
+    {
+      "code": "Lm",
+      "description": "Modifier Letter"
+    },
+    {
+      "code": "Lo",
+      "description": "Other Letter"
+    },
+    {
+      "code": "M",
+      "description": "Mark"
     },
     {
       "code": "Mn",
-      "description": "Mark, Nonspacing"
+      "description": "Non-Spacing Mark"
+    },
+    {
+      "code": "Mc",
+      "description": "Spacing Combining Mark"
+    },
+    {
+      "code": "Me",
+      "description": "Enclosing Mark"
+    },
+    {
+      "code": "N",
+      "description": "Number"
     },
     {
       "code": "Nd",
-      "description": "Number, Decimal Digit"
+      "description": "Decimal Digit Number"
     },
     {
       "code": "Nl",
-      "description": "Number, Letter"
+      "description": "Letter Number"
     },
     {
       "code": "No",
-      "description": "Number, Other"
+      "description": "Other Number"
     },
     {
-      "code": "Pc",
-      "description": "Punctuation, Connector"
-    },
-    {
-      "code": "Pd",
-      "description": "Punctuation, Dash"
-    },
-    {
-      "code": "Pe",
-      "description": "Punctuation, Close"
-    },
-    {
-      "code": "Pf",
-      "description": "Punctuation, Final quote (may behave like Ps or Pe depending on usage)"
-    },
-    {
-      "code": "Pi",
-      "description": "Punctuation, Initial quote (may behave like Ps or Pe depending on usage)"
-    },
-    {
-      "code": "Po",
-      "description": "Punctuation, Other"
-    },
-    {
-      "code": "Ps",
-      "description": "Punctuation, Open"
-    },
-    {
-      "code": "Sc",
-      "description": "Symbol, Currency"
-    },
-    {
-      "code": "Sk",
-      "description": "Symbol, Modifier"
+      "code": "S",
+      "description": "Symbol"
     },
     {
       "code": "Sm",
-      "description": "Symbol, Math"
+      "description": "Math Symbol"
+    },
+    {
+      "code": "Sc",
+      "description": "Currency Symbol"
+    },
+    {
+      "code": "Sk",
+      "description": "Modifier Symbol"
     },
     {
       "code": "So",
-      "description": "Symbol, Other"
+      "description": "Other Symbol"
     },
     {
-      "code": "Zl",
-      "description": "Separator, Line"
+      "code": "P",
+      "description": "Punctuation"
     },
     {
-      "code": "Zp",
-      "description": "Separator, Paragraph"
+      "code": "Pc",
+      "description": "Connector Punctuation"
+    },
+    {
+      "code": "Pd",
+      "description": "Dash Punctuation"
+    },
+    {
+      "code": "Ps",
+      "description": "Open Punctuation"
+    },
+    {
+      "code": "Pe",
+      "description": "Close Punctuation"
+    },
+    {
+      "code": "Pi",
+      "description": "Initial Punctuation"
+    },
+    {
+      "code": "Pf",
+      "description": "Final Punctuation"
+    },
+    {
+      "code": "Po",
+      "description": "Other Punctuation"
+    },
+    {
+      "code": "Z",
+      "description": "Separator"
     },
     {
       "code": "Zs",
-      "description": "Separator, Space"
+      "description": "Space Separator"
+    },
+    {
+      "code": "Zl",
+      "description": "Line Separator"
+    },
+    {
+      "code": "Zp",
+      "description": "Paragraph Separator"
+    },
+    {
+      "code": "C",
+      "description": "Other"
+    },
+    {
+      "code": "Cc",
+      "description": "Control"
+    },
+    {
+      "code": "Cf",
+      "description": "Format"
+    },
+    {
+      "code": "Cs",
+      "description": "Surrogate"
+    },
+    {
+      "code": "Co",
+      "description": "Private Use"
+    },
+    {
+      "code": "Cn",
+      "description": "Unassigned"
     }
-]
+  ]
 
 
 function fuzzyMatch(haystack, needle) {

--- a/symbols.js
+++ b/symbols.js
@@ -1152,6 +1152,23 @@ function isCategoryValid(category){
     return categoryCodes.includes(category);
 }
 
+function setCategoryNames(category){
+    const categorySelect = document.querySelector(".search select");
+
+    unicodeCategories.forEach(cat => {
+        /* for each category in the `categories` array, create an option element in the category select */
+        const option = document.createElement("option");
+        option.value = cat.code;
+        option.textContent = cat.description;
+        categorySelect.appendChild(option);
+    })
+
+    if (category && isCategoryValid(category)) {
+        /* if the category is provided, set the value of the category select */
+        categorySelect.value = category;
+    }
+}
+
 function renderSymbols(searchTerm) {
     const parent = document.querySelector(".symbols");
     parent.innerHTML = "";

--- a/symbols.js
+++ b/symbols.js
@@ -1191,7 +1191,17 @@ function renderSymbols(searchTerm) {
         return;
     }
 
+    const category = document.querySelector(".search select").value;
+
     for (const symbol of results) {
+        if (category && isCategoryValid(category)) {
+            /* if the category is provided, exclude results that do not match the category by checking the glyph's unicode category with regex */
+            let regexpFilter = new RegExp(`\\p{gc=${category}}`, 'gu')
+            if (!symbol.glyph.match(regexpFilter)) {
+                continue;
+            }
+        }
+
         const elem = document.createElement("div");
         const glyphElem = document.createElement("div");
         const nameElem = document.createElement("div");

--- a/symbols.js
+++ b/symbols.js
@@ -929,155 +929,155 @@ const symbols = [
 ];
 
 const unicodeCategories = [
-    {
-      "code": "L",
-      "description": "Letter"
-    },
-    {
-      "code": "Lu",
-      "description": "Uppercase Letter"
-    },
-    {
-      "code": "Ll",
-      "description": "Lowercase Letter"
-    },
-    {
-      "code": "Lt",
-      "description": "Titlecase Letter"
-    },
-    {
-      "code": "Lm",
-      "description": "Modifier Letter"
-    },
-    {
-      "code": "Lo",
-      "description": "Other Letter"
-    },
-    {
-      "code": "M",
-      "description": "Mark"
-    },
-    {
-      "code": "Mn",
-      "description": "Non-Spacing Mark"
-    },
-    {
-      "code": "Mc",
-      "description": "Spacing Combining Mark"
-    },
-    {
-      "code": "Me",
-      "description": "Enclosing Mark"
-    },
-    {
-      "code": "N",
-      "description": "Number"
-    },
-    {
-      "code": "Nd",
-      "description": "Decimal Digit Number"
-    },
-    {
-      "code": "Nl",
-      "description": "Letter Number"
-    },
-    {
-      "code": "No",
-      "description": "Other Number"
-    },
-    {
-      "code": "S",
-      "description": "Symbol"
-    },
-    {
-      "code": "Sm",
-      "description": "Math Symbol"
-    },
-    {
-      "code": "Sc",
-      "description": "Currency Symbol"
-    },
-    {
-      "code": "Sk",
-      "description": "Modifier Symbol"
-    },
-    {
-      "code": "So",
-      "description": "Other Symbol"
-    },
-    {
-      "code": "P",
-      "description": "Punctuation"
-    },
-    {
-      "code": "Pc",
-      "description": "Connector Punctuation"
-    },
-    {
-      "code": "Pd",
-      "description": "Dash Punctuation"
-    },
-    {
-      "code": "Ps",
-      "description": "Open Punctuation"
-    },
-    {
-      "code": "Pe",
-      "description": "Close Punctuation"
-    },
-    {
-      "code": "Pi",
-      "description": "Initial Punctuation"
-    },
-    {
-      "code": "Pf",
-      "description": "Final Punctuation"
-    },
-    {
-      "code": "Po",
-      "description": "Other Punctuation"
-    },
-    {
-      "code": "Z",
-      "description": "Separator"
-    },
-    {
-      "code": "Zs",
-      "description": "Space Separator"
-    },
-    {
-      "code": "Zl",
-      "description": "Line Separator"
-    },
-    {
-      "code": "Zp",
-      "description": "Paragraph Separator"
-    },
-    {
-      "code": "C",
-      "description": "Other"
-    },
-    {
-      "code": "Cc",
-      "description": "Control"
-    },
-    {
-      "code": "Cf",
-      "description": "Format"
-    },
-    {
-      "code": "Cs",
-      "description": "Surrogate"
-    },
-    {
-      "code": "Co",
-      "description": "Private Use"
-    },
-    {
-      "code": "Cn",
-      "description": "Unassigned"
-    }
-  ]
+  {
+    "code": "L",
+    "description": "Letter"
+  },
+  {
+    "code": "Lu",
+    "description": "Uppercase Letter"
+  },
+  {
+    "code": "Ll",
+    "description": "Lowercase Letter"
+  },
+  {
+    "code": "Lt",
+    "description": "Titlecase Letter"
+  },
+  {
+    "code": "Lm",
+    "description": "Modifier Letter"
+  },
+  {
+    "code": "Lo",
+    "description": "Other Letter"
+  },
+  {
+    "code": "M",
+    "description": "Mark"
+  },
+  {
+    "code": "Mn",
+    "description": "Non-Spacing Mark"
+  },
+  {
+    "code": "Mc",
+    "description": "Spacing Combining Mark"
+  },
+  {
+    "code": "Me",
+    "description": "Enclosing Mark"
+  },
+  {
+    "code": "N",
+    "description": "Number"
+  },
+  {
+    "code": "Nd",
+    "description": "Decimal Digit Number"
+  },
+  {
+    "code": "Nl",
+    "description": "Letter Number"
+  },
+  {
+    "code": "No",
+    "description": "Other Number"
+  },
+  {
+    "code": "S",
+    "description": "Symbol"
+  },
+  {
+    "code": "Sm",
+    "description": "Math Symbol"
+  },
+  {
+    "code": "Sc",
+    "description": "Currency Symbol"
+  },
+  {
+    "code": "Sk",
+    "description": "Modifier Symbol"
+  },
+  {
+    "code": "So",
+    "description": "Other Symbol"
+  },
+  {
+    "code": "P",
+    "description": "Punctuation"
+  },
+  {
+    "code": "Pc",
+    "description": "Connector Punctuation"
+  },
+  {
+    "code": "Pd",
+    "description": "Dash Punctuation"
+  },
+  {
+    "code": "Ps",
+    "description": "Open Punctuation"
+  },
+  {
+    "code": "Pe",
+    "description": "Close Punctuation"
+  },
+  {
+    "code": "Pi",
+    "description": "Initial Punctuation"
+  },
+  {
+    "code": "Pf",
+    "description": "Final Punctuation"
+  },
+  {
+    "code": "Po",
+    "description": "Other Punctuation"
+  },
+  {
+    "code": "Z",
+    "description": "Separator"
+  },
+  {
+    "code": "Zs",
+    "description": "Space Separator"
+  },
+  {
+    "code": "Zl",
+    "description": "Line Separator"
+  },
+  {
+    "code": "Zp",
+    "description": "Paragraph Separator"
+  },
+  {
+    "code": "C",
+    "description": "Other"
+  },
+  {
+    "code": "Cc",
+    "description": "Control"
+  },
+  {
+    "code": "Cf",
+    "description": "Format"
+  },
+  {
+    "code": "Cs",
+    "description": "Surrogate"
+  },
+  {
+    "code": "Co",
+    "description": "Private Use"
+  },
+  {
+    "code": "Cn",
+    "description": "Unassigned"
+  }
+]
 
 
 function fuzzyMatch(haystack, needle) {

--- a/symbols.js
+++ b/symbols.js
@@ -1249,6 +1249,7 @@ function renderSymbols(searchTerm) {
 document.addEventListener("DOMContentLoaded", () => {
     const search = window.location.hash ? window.location.hash.substring(1) : "";
     renderSymbols(search);
+    setCategoryNames("");
 
     const searchInput = document.querySelector(".search input");
     searchInput.value = search;


### PR DESCRIPTION
Found this project and thought it would be cool if this feature was added. Hope this fits within the scope of the project, just want to contibute :)

Adds the ability to filter the displayed symbols based on the ["General Category Value"](https://www.unicode.org/reports/tr44/#GC_Values_Table) of the Unicode character.

<img width="49%" height="auto" alt="Screenshot 2025-09-20 at 3 04 39 PM" src="https://github.com/user-attachments/assets/2dc331ea-c69e-4712-9e0d-78ddd79166d8" />
<img width="49%" height="auto" alt="Screenshot 2025-09-20 at 3 03 47 PM" src="https://github.com/user-attachments/assets/adc2c184-b4a8-4746-bc6e-96163d40a2e0" />

Before rendering each symbol element, it checks whether the glyph's unicode category matches the selected category, and it excludes the symbol from the results if it does not:

```js
if (category && isCategoryValid(category)) {
    /* if the category is provided, exclude results that do not match the category by checking the glyph's unicode category with regex */
    let regexpFilter = new RegExp(`\\p{gc=${category}}`, 'gu')
    if (!symbol.glyph.match(regexpFilter)) {
        continue;
    }
 }
```

We're able to check the Unicode category of the glyph with [regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) and Unicode character properties. If there is a category selected, it checks the selected category value against the value of the glyph's `General_Category` (or `gc`) property.

The category can be selected through the `<select>` element in the search bar, or through the `category` URL parameter.

Plays nicely with the search function and existing URL `#` search system

<img width="auto" height="300px" alt="Screenshot 2025-09-20 at 3 05 21 PM" src="https://github.com/user-attachments/assets/91e6b017-dd6b-421a-a0b1-a7c186380841" />

As far as I can tell (I could be wrong), there's not really a way to generate the list of Unicode categories programatically. It seems to require a hardcoded list. Maybe a workaround could be found though, given the category data is there to check against -- it just isn't easily exposed.

However, the JSON object representing the Unicode categories can be generated by running this script in the browser console on the official [Unicode Technical Standard 18: Unicode Regular Expressions](https://unicode.org/reports/tr18/#General_Category_Property) page:

```js
(() => {
    const tr = document.querySelector('body > div > div:nth-child(130) > center > table > tbody > tr');
    if (!tr) return console.error("Could not find table row");

    const tds = Array.from(tr.children);
    if (tds.length !== 3) return console.error("Row does not have 3 cells");

    let allData = [];
    for (const td of tds) {
      const table = td.querySelector('table');
      if (!table) continue;
      const rows = Array.from(table.querySelectorAll('tr')).slice(1);
      for (const row of rows) {
        const cells = row.querySelectorAll('td');
        if (cells.length === 2) {
          allData.push({
            code: cells[0].textContent.trim(),
            description: cells[1].textContent.trim()
          });
        }
      }
    }

    allData = allData.slice(0,-3)

    console.log(JSON.stringify(allData, null, 2));
  })();
```


